### PR TITLE
Migrate API to NestJS structure and add modules, controllers, guards, and decorators

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -4,9 +4,9 @@
   "description": "API for Lens Music - A music distribution platform.",
   "main": "src/server.js",
   "scripts": {
-    "build": "npm install && tsc",
-    "dev": "nodemon --exec ts-node ./src/server.ts",
-    "start": "npm run build && node ./dist/server.js"
+    "build": "tsc",
+    "dev": "nodemon --exec ts-node ./src/main.ts",
+    "start": "node ./dist/main.js"
   },
   "repository": {
     "type": "git",
@@ -39,7 +39,14 @@
     "reflect-metadata": "^0.2.2",
     "ts-node": "^10.9.2",
     "typeorm": "^0.3.20",
-    "typescript": "^5.4.5"
+    "typescript": "^5.4.5",
+    "@nestjs/common": "^10.4.2",
+    "@nestjs/config": "^3.2.3",
+    "@nestjs/core": "^10.4.2",
+    "@nestjs/jwt": "^10.2.0",
+    "@nestjs/platform-express": "^10.4.2",
+    "@nestjs/typeorm": "^10.0.2",
+    "rxjs": "^7.8.1"
   },
   "devDependencies": {
     "@types/cors": "^2.8.17",

--- a/api/src/app.module.ts
+++ b/api/src/app.module.ts
@@ -1,0 +1,37 @@
+import { Module } from '@nestjs/common';
+import { ConfigModule } from '@nestjs/config';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { AuthModule } from './modules/auth/auth.module';
+import { UsersModule } from './modules/users/users.module';
+import { LabelsModule } from './modules/labels/labels.module';
+import { ArtistsModule } from './modules/artists/artists.module';
+import { ReleasesModule } from './modules/releases/releases.module';
+
+@Module({
+  imports: [
+    ConfigModule.forRoot({ isGlobal: true }),
+    TypeOrmModule.forRoot({
+      type: 'postgres',
+      host: process.env.DB_HOST,
+      port: Number(process.env.DB_PORT),
+      username: process.env.DB_USER,
+      password: process.env.DB_PASSWORD,
+      database: process.env.DB_NAME,
+      synchronize: true,
+      autoLoadEntities: false,
+      entities: [`${__dirname}/**/entities/*.{ts,js}`],
+      migrations: [`${__dirname}/**/migrations/*.{ts,js}`],
+      ssl: ['localhost', '127.0.0.1', '/var/run/postgresql'].includes(
+        process.env.DB_HOST || ''
+      )
+        ? false
+        : { rejectUnauthorized: false },
+    }),
+    AuthModule,
+    UsersModule,
+    LabelsModule,
+    ArtistsModule,
+    ReleasesModule,
+  ],
+})
+export class AppModule {}

--- a/api/src/common/decorators/current-user.decorator.ts
+++ b/api/src/common/decorators/current-user.decorator.ts
@@ -1,0 +1,14 @@
+import { createParamDecorator, ExecutionContext } from '@nestjs/common';
+
+export interface AuthUser {
+  id: string;
+  email: string;
+  role: string;
+}
+
+export const CurrentUser = createParamDecorator(
+  (_data: unknown, ctx: ExecutionContext): AuthUser | undefined => {
+    const request = ctx.switchToHttp().getRequest();
+    return request.user;
+  }
+);

--- a/api/src/common/decorators/roles.decorator.ts
+++ b/api/src/common/decorators/roles.decorator.ts
@@ -1,0 +1,4 @@
+import { SetMetadata } from '@nestjs/common';
+
+export const ROLES_KEY = 'roles';
+export const Roles = (...roles: string[]) => SetMetadata(ROLES_KEY, roles);

--- a/api/src/common/filters/http-exception.filter.ts
+++ b/api/src/common/filters/http-exception.filter.ts
@@ -1,0 +1,27 @@
+import {
+  ArgumentsHost,
+  Catch,
+  ExceptionFilter,
+  HttpException,
+  HttpStatus,
+} from '@nestjs/common';
+
+@Catch()
+export class HttpExceptionFilter implements ExceptionFilter {
+  catch(exception: unknown, host: ArgumentsHost) {
+    const ctx = host.switchToHttp();
+    const response = ctx.getResponse();
+
+    const httpException =
+      exception instanceof HttpException
+        ? exception
+        : new HttpException('Internal server error', HttpStatus.INTERNAL_SERVER_ERROR);
+
+    const status = httpException.getStatus();
+    const payload = httpException.getResponse();
+
+    response.status(status).json(
+      typeof payload === 'string' ? { message: payload } : payload
+    );
+  }
+}

--- a/api/src/common/guards/jwt-auth.guard.ts
+++ b/api/src/common/guards/jwt-auth.guard.ts
@@ -1,0 +1,28 @@
+import {
+  CanActivate,
+  ExecutionContext,
+  Injectable,
+  UnauthorizedException,
+} from '@nestjs/common';
+import jwt from 'jsonwebtoken';
+
+@Injectable()
+export class JwtAuthGuard implements CanActivate {
+  canActivate(context: ExecutionContext): boolean {
+    const request = context.switchToHttp().getRequest();
+    const authHeader = request.headers?.authorization as string | undefined;
+    const token = authHeader?.split(' ')[1];
+
+    if (!token) {
+      throw new UnauthorizedException('Unauthorized');
+    }
+
+    try {
+      const decoded = jwt.verify(token, process.env.JWT_SECRET as string);
+      request.user = decoded;
+      return true;
+    } catch {
+      throw new UnauthorizedException('Unauthorized');
+    }
+  }
+}

--- a/api/src/common/guards/roles.guard.ts
+++ b/api/src/common/guards/roles.guard.ts
@@ -1,0 +1,33 @@
+import {
+  CanActivate,
+  ExecutionContext,
+  ForbiddenException,
+  Injectable,
+} from '@nestjs/common';
+import { Reflector } from '@nestjs/core';
+import { ROLES_KEY } from '../decorators/roles.decorator';
+
+@Injectable()
+export class RolesGuard implements CanActivate {
+  constructor(private readonly reflector: Reflector) {}
+
+  canActivate(context: ExecutionContext): boolean {
+    const requiredRoles = this.reflector.getAllAndOverride<string[]>(ROLES_KEY, [
+      context.getHandler(),
+      context.getClass(),
+    ]);
+
+    if (!requiredRoles?.length) {
+      return true;
+    }
+
+    const request = context.switchToHttp().getRequest();
+    const user = request.user;
+
+    if (!user || !requiredRoles.includes(user.role)) {
+      throw new ForbiddenException('Forbidden');
+    }
+
+    return true;
+  }
+}

--- a/api/src/main.ts
+++ b/api/src/main.ts
@@ -1,0 +1,29 @@
+import 'reflect-metadata';
+import 'dotenv/config';
+import { NestFactory } from '@nestjs/core';
+import { ValidationPipe } from '@nestjs/common';
+import { AppModule } from './app.module';
+import { HttpExceptionFilter } from './common/filters/http-exception.filter';
+import { AppDataSource } from './data-source';
+
+async function bootstrap() {
+  await AppDataSource.initialize();
+  const app = await NestFactory.create(AppModule);
+
+  app.setGlobalPrefix('api');
+  app.enableCors();
+  app.useGlobalPipes(
+    new ValidationPipe({
+      whitelist: true,
+      transform: true,
+      forbidUnknownValues: false,
+    })
+  );
+  app.useGlobalFilters(new HttpExceptionFilter());
+
+  const port = Number(process.env.PORT) || 8080;
+  await app.listen(port);
+  console.log(`API running on port ${port}`);
+}
+
+bootstrap();

--- a/api/src/modules/artists/artists.controller.ts
+++ b/api/src/modules/artists/artists.controller.ts
@@ -1,0 +1,128 @@
+import {
+  BadRequestException,
+  Body,
+  Controller,
+  Delete,
+  ForbiddenException,
+  Get,
+  HttpCode,
+  HttpStatus,
+  NotFoundException,
+  Param,
+  Patch,
+  Post,
+  Query,
+  UseGuards,
+} from '@nestjs/common';
+import { ArtistService } from '../../services/artist.service';
+import { JwtAuthGuard } from '../../common/guards/jwt-auth.guard';
+import { CurrentUser, AuthUser } from '../../common/decorators/current-user.decorator';
+import { ROLES } from '../../constants/auth.constant';
+import { STATUSES } from '../../constants/artist.constants';
+
+@Controller('artists')
+@UseGuards(JwtAuthGuard)
+export class ArtistsController {
+  constructor(private readonly artistService: ArtistService) {}
+
+  @Post()
+  async createArtist(
+    @Body() body: { name: string; status: string },
+    @CurrentUser() user: AuthUser
+  ) {
+    const { name, status } = body;
+    if (!name) {
+      throw new BadRequestException('Name is required');
+    }
+
+    const newArtist = await this.artistService.createArtist({
+      name,
+      status,
+      userId: user.id,
+    });
+
+    return { message: 'Artist created successfully', data: newArtist };
+  }
+
+  @Get()
+  async fetchArtists(
+    @Query('size') size = '10',
+    @Query('page') page = '0',
+    @Query('labelId') labelId: string | undefined,
+    @CurrentUser() user: AuthUser
+  ) {
+    let condition: Record<string, unknown> = {};
+
+    if (user?.role !== ROLES.ADMIN) {
+      condition = { ...condition, userId: user.id, status: STATUSES.ACTIVE };
+    }
+
+    if (labelId) {
+      condition = { ...condition, labelId };
+    }
+
+    const artists = await this.artistService.fetchArtists({
+      condition,
+      size: Number(size),
+      page: Number(page),
+    });
+
+    return { message: 'Artists fetched successfully', data: artists };
+  }
+
+  @Get(':id')
+  async getArtistById(@Param('id') id: string, @CurrentUser() user: AuthUser) {
+    const artist = await this.artistService.getArtistById(id);
+
+    if (!artist) {
+      throw new NotFoundException('Artist not found');
+    }
+
+    if (user?.role !== ROLES.ADMIN && artist.status !== STATUSES.ACTIVE) {
+      throw new ForbiddenException('Forbidden');
+    }
+
+    return { message: 'Artist fetched successfully', data: artist };
+  }
+
+  @Patch(':id')
+  async updateArtist(
+    @Param('id') id: string,
+    @Body() body: { name: string; status: string },
+    @CurrentUser() user: AuthUser
+  ) {
+    const { name, status } = body;
+
+    if (!name) {
+      throw new BadRequestException('Name is required');
+    }
+
+    const artist = await this.artistService.getArtistById(id);
+    if (!artist) {
+      throw new NotFoundException('Artist not found');
+    }
+
+    if (user?.role !== ROLES.ADMIN && artist.status !== STATUSES.ACTIVE) {
+      throw new ForbiddenException('Forbidden');
+    }
+
+    const updatedArtist = await this.artistService.updateArtist({
+      id,
+      name: name || artist.name,
+      status: status || artist.status,
+      userId: artist.userId,
+    });
+
+    return { message: 'Artist updated successfully', data: updatedArtist };
+  }
+
+  @Delete(':id')
+  @HttpCode(HttpStatus.NO_CONTENT)
+  async deleteArtist(@Param('id') id: string, @CurrentUser() user: AuthUser) {
+    if (user?.role !== ROLES.ADMIN && user?.id !== id) {
+      throw new ForbiddenException('Forbidden');
+    }
+
+    await this.artistService.deleteArtist(id);
+  }
+}

--- a/api/src/modules/artists/artists.module.ts
+++ b/api/src/modules/artists/artists.module.ts
@@ -1,0 +1,9 @@
+import { Module } from '@nestjs/common';
+import { ArtistsController } from './artists.controller';
+import { ArtistService } from '../../services/artist.service';
+
+@Module({
+  controllers: [ArtistsController],
+  providers: [ArtistService],
+})
+export class ArtistsModule {}

--- a/api/src/modules/auth/auth.controller.ts
+++ b/api/src/modules/auth/auth.controller.ts
@@ -1,0 +1,89 @@
+import {
+  BadRequestException,
+  Body,
+  ConflictException,
+  Controller,
+  HttpCode,
+  HttpStatus,
+  Post,
+} from '@nestjs/common';
+import jwt from 'jsonwebtoken';
+import { validateEmail } from '../../helpers/validations.helper';
+import { AuthService } from '../../services/auth.service';
+import { UserService } from '../../services/user.service';
+
+@Controller('auth')
+export class AuthController {
+  constructor(
+    private readonly authService: AuthService,
+    private readonly userService: UserService
+  ) {}
+
+  @Post('signup')
+  async signup(
+    @Body()
+    body: {
+      email: string;
+      name: string;
+      phone: string;
+      password: string;
+      role: string;
+    }
+  ) {
+    const { email, name, phone, password, role } = body;
+
+    if (!email || !name || !password) {
+      throw new BadRequestException('Email, name, and password are required');
+    }
+
+    const { error } = validateEmail(email);
+    if (error) {
+      throw new BadRequestException(error.message);
+    }
+
+    const userExists = await this.userService.findUserByEmail(email);
+    if (userExists) {
+      throw new ConflictException({
+        message: 'User already exists',
+        data: { id: userExists.id, email: userExists.email },
+      });
+    }
+
+    const newUser = await this.authService.signup({
+      email,
+      name,
+      phone,
+      password,
+      role,
+    });
+
+    const token = jwt.sign(
+      { id: newUser.id, email: newUser.email, role: newUser.role },
+      process.env.JWT_SECRET as string,
+      { expiresIn: '1d' }
+    );
+
+    return {
+      message: 'You have signed up successfully!',
+      data: { user: { ...newUser, password: undefined }, token },
+    };
+  }
+
+  @Post('login')
+  @HttpCode(HttpStatus.OK)
+  async login(@Body() body: { email: string; password: string }) {
+    const { email, password } = body;
+    const user = await this.authService.login({ email, password });
+
+    const token = jwt.sign(
+      { id: user.id, email: user.email, role: user.role },
+      process.env.JWT_SECRET as string,
+      { expiresIn: '1w' }
+    );
+
+    return {
+      message: 'You have logged in successfully!',
+      data: { user: { ...user, password: undefined }, token },
+    };
+  }
+}

--- a/api/src/modules/auth/auth.module.ts
+++ b/api/src/modules/auth/auth.module.ts
@@ -1,0 +1,10 @@
+import { Module } from '@nestjs/common';
+import { AuthController } from './auth.controller';
+import { AuthService } from '../../services/auth.service';
+import { UserService } from '../../services/user.service';
+
+@Module({
+  controllers: [AuthController],
+  providers: [AuthService, UserService],
+})
+export class AuthModule {}

--- a/api/src/modules/labels/labels.controller.ts
+++ b/api/src/modules/labels/labels.controller.ts
@@ -1,0 +1,124 @@
+import {
+  BadRequestException,
+  Body,
+  Controller,
+  Delete,
+  Get,
+  HttpCode,
+  HttpStatus,
+  NotFoundException,
+  Param,
+  Patch,
+  Post,
+  Query,
+  UseGuards,
+} from '@nestjs/common';
+import { LabelService } from '../../services/label.service';
+import { JwtAuthGuard } from '../../common/guards/jwt-auth.guard';
+import { CurrentUser, AuthUser } from '../../common/decorators/current-user.decorator';
+import { validateCountry, validateEmail } from '../../helpers/validations.helper';
+
+@Controller('labels')
+@UseGuards(JwtAuthGuard)
+export class LabelsController {
+  constructor(private readonly labelService: LabelService) {}
+
+  @Post()
+  async createLabel(
+    @Body() body: { name: string; description: string; email: string; country: string },
+    @CurrentUser() user: AuthUser
+  ) {
+    const { name, description, email, country } = body;
+
+    if (!name) {
+      throw new BadRequestException('Name is required');
+    }
+
+    if (email) {
+      const { error } = validateEmail(email);
+      if (error) {
+        throw new BadRequestException(error.message);
+      }
+    }
+
+    if (country && !validateCountry(country)) {
+      throw new BadRequestException('Invalid country value');
+    }
+
+    const label = await this.labelService.createLabel({
+      name,
+      description,
+      email,
+      userId: user.id,
+      country,
+    });
+
+    return { message: 'Label created successfully', data: label };
+  }
+
+  @Patch(':id')
+  async updateLabel(
+    @Param('id') id: string,
+    @Body() body: { name: string; description: string; email: string; country: string }
+  ) {
+    const { name, description, email, country } = body;
+
+    if (email) {
+      const { error } = validateEmail(email);
+      if (error) {
+        throw new BadRequestException(error.message);
+      }
+    }
+
+    if (country && !validateCountry(country)) {
+      throw new BadRequestException('Invalid country value');
+    }
+
+    const labelExists = await this.labelService.getLabelById(id);
+    if (!labelExists) {
+      throw new NotFoundException('Label not found');
+    }
+
+    const updatedLabel = await this.labelService.updateLabel({
+      id,
+      name,
+      description,
+      email,
+      country,
+    });
+
+    return { message: 'Label updated successfully', data: updatedLabel };
+  }
+
+  @Delete(':id')
+  @HttpCode(HttpStatus.NO_CONTENT)
+  async deleteLabel(@Param('id') id: string) {
+    const labelExists = await this.labelService.getLabelById(id);
+    if (!labelExists) {
+      throw new NotFoundException('Label not found');
+    }
+
+    await this.labelService.deleteLabel(id);
+  }
+
+  @Get()
+  async fetchLabels(@Query('size') size = '10', @Query('page') page = '0', @Query() query: Record<string, string>) {
+    const labels = await this.labelService.fetchLabels({
+      size: Number(size),
+      page: Number(page),
+      condition: { ...query, size: undefined, page: undefined },
+    });
+
+    return { message: 'Labels returned successfully', data: labels };
+  }
+
+  @Get(':id')
+  async getLabel(@Param('id') id: string) {
+    const label = await this.labelService.getLabelById(id);
+    if (!label) {
+      throw new NotFoundException('Label not found');
+    }
+
+    return { message: 'Label found successfully', data: label };
+  }
+}

--- a/api/src/modules/labels/labels.module.ts
+++ b/api/src/modules/labels/labels.module.ts
@@ -1,0 +1,10 @@
+import { Module } from '@nestjs/common';
+import { LabelsController } from './labels.controller';
+import { LabelService } from '../../services/label.service';
+import { UserService } from '../../services/user.service';
+
+@Module({
+  controllers: [LabelsController],
+  providers: [LabelService, UserService],
+})
+export class LabelsModule {}

--- a/api/src/modules/releases/releases.controller.ts
+++ b/api/src/modules/releases/releases.controller.ts
@@ -1,0 +1,114 @@
+import {
+  BadRequestException,
+  Body,
+  ConflictException,
+  Controller,
+  Get,
+  NotFoundException,
+  Param,
+  Post,
+  Query,
+  UseGuards,
+} from '@nestjs/common';
+import moment from 'moment';
+import { JwtAuthGuard } from '../../common/guards/jwt-auth.guard';
+import { CurrentUser, AuthUser } from '../../common/decorators/current-user.decorator';
+import { ReleaseService } from '../../services/release.service';
+import { generateCatalogNumber } from '../../helpers/strings.helper';
+import { ROLES } from '../../constants/auth.constant';
+
+@Controller('releases')
+@UseGuards(JwtAuthGuard)
+export class ReleasesController {
+  constructor(private readonly releaseService: ReleaseService) {}
+
+  @Post()
+  async createRelease(
+    @Body()
+    body: {
+      title: string;
+      upc: string;
+      releaseDate: string;
+      version?: string;
+      productionYear: number;
+      labelId: string;
+    },
+    @CurrentUser() user: AuthUser
+  ) {
+    const {
+      title,
+      upc,
+      releaseDate,
+      version = 'original',
+      productionYear,
+      labelId,
+    } = body;
+
+    if (!title || !releaseDate || !productionYear) {
+      throw new BadRequestException(
+        'Title, release date, and production year are required'
+      );
+    }
+
+    const releaseExists = await this.releaseService.checkIfLabelExists({
+      labelId,
+      productionYear,
+      releaseDate: moment(releaseDate).format(),
+      title,
+      userId: user.id,
+      version,
+    });
+
+    if (releaseExists) {
+      throw new ConflictException({
+        message: 'Release already exists',
+        data: { id: releaseExists.id },
+      });
+    }
+
+    const newRelease = await this.releaseService.createRelease({
+      title,
+      upc,
+      releaseDate: moment(releaseDate).format(),
+      version,
+      productionYear,
+      catalogNumber: generateCatalogNumber(productionYear),
+      labelId,
+      userId: user.id,
+    });
+
+    return { message: 'Release created successfully', data: newRelease };
+  }
+
+  @Get()
+  async fetchReleases(
+    @CurrentUser() user: AuthUser,
+    @Query('size') size = '10',
+    @Query('page') page = '0',
+    @Query('labelId') labelId?: string,
+    @Query('userId') userId?: string
+  ) {
+    const condition: Record<string, string | null | undefined> = {
+      userId: user.role !== ROLES.ADMIN ? userId || user.id : null,
+      labelId: labelId || undefined,
+    };
+
+    const releases = await this.releaseService.fetchReleases({
+      size: Number(size),
+      page: Number(page),
+      condition,
+    });
+
+    return { message: 'Releases fetched successfully', data: releases };
+  }
+
+  @Get(':id')
+  async getRelease(@Param('id') id: string) {
+    const release = await this.releaseService.getReleaseById(id);
+    if (!release) {
+      throw new NotFoundException('Release not found');
+    }
+
+    return { message: 'Release fetched successfully', data: release };
+  }
+}

--- a/api/src/modules/releases/releases.module.ts
+++ b/api/src/modules/releases/releases.module.ts
@@ -1,0 +1,9 @@
+import { Module } from '@nestjs/common';
+import { ReleasesController } from './releases.controller';
+import { ReleaseService } from '../../services/release.service';
+
+@Module({
+  controllers: [ReleasesController],
+  providers: [ReleaseService],
+})
+export class ReleasesModule {}

--- a/api/src/modules/users/users.controller.ts
+++ b/api/src/modules/users/users.controller.ts
@@ -1,0 +1,30 @@
+import {
+  Controller,
+  Delete,
+  HttpCode,
+  HttpStatus,
+  NotFoundException,
+  Param,
+  UseGuards,
+} from '@nestjs/common';
+import { UserService } from '../../services/user.service';
+import { JwtAuthGuard } from '../../common/guards/jwt-auth.guard';
+import { RolesGuard } from '../../common/guards/roles.guard';
+import { Roles } from '../../common/decorators/roles.decorator';
+import { ROLES } from '../../constants/auth.constant';
+
+@Controller('users')
+@UseGuards(JwtAuthGuard, RolesGuard)
+export class UsersController {
+  constructor(private readonly userService: UserService) {}
+
+  @Delete(':id')
+  @Roles(ROLES.ADMIN)
+  @HttpCode(HttpStatus.NO_CONTENT)
+  async deleteUser(@Param('id') id: string) {
+    const deletedUser = await this.userService.deleteUser(id);
+    if (!deletedUser) {
+      throw new NotFoundException('User not found');
+    }
+  }
+}

--- a/api/src/modules/users/users.module.ts
+++ b/api/src/modules/users/users.module.ts
@@ -1,0 +1,10 @@
+import { Module } from '@nestjs/common';
+import { UsersController } from './users.controller';
+import { UserService } from '../../services/user.service';
+
+@Module({
+  controllers: [UsersController],
+  providers: [UserService],
+  exports: [UserService],
+})
+export class UsersModule {}

--- a/api/src/services/artist.service.ts
+++ b/api/src/services/artist.service.ts
@@ -1,3 +1,4 @@
+import { Injectable } from '@nestjs/common';
 import { Repository } from 'typeorm';
 import { AppDataSource } from '../data-source';
 import { Artist } from '../entities/artist.entity';
@@ -5,6 +6,7 @@ import { getPagination, getPagingData } from '../helpers/pagination.helper';
 import { UUID } from '../types/common.types';
 import { ArtistPagination } from '../types/models/artist.types';
 
+@Injectable()
 export class ArtistService {
   private artistRepository: Repository<Artist>;
 

--- a/api/src/services/auth.service.ts
+++ b/api/src/services/auth.service.ts
@@ -1,9 +1,11 @@
+import { Injectable } from '@nestjs/common';
 import { Repository } from 'typeorm';
 import { AppDataSource } from '../data-source';
 import { User } from '../entities/user.entity';
 import { comparePasswords, hashPassword } from '../helpers/encryptions.helper';
 import { ValidationError } from '../helpers/errors.helper';
 
+@Injectable()
 export class AuthService {
   private userRepository: Repository<User>;
 

--- a/api/src/services/label.service.ts
+++ b/api/src/services/label.service.ts
@@ -1,3 +1,4 @@
+import { Injectable } from '@nestjs/common';
 import { DeleteResult, Repository } from 'typeorm';
 import { AppDataSource } from '../data-source';
 import { Label } from '../entities/label.entity';
@@ -6,6 +7,7 @@ import { UserService } from './user.service';
 import { UUID } from '../types/common.types';
 import { LabelPagination } from '../types/models/label.types';
 
+@Injectable()
 export class LabelService {
   private labelRepository: Repository<Label>;
   private userService = new UserService();

--- a/api/src/services/release.service.ts
+++ b/api/src/services/release.service.ts
@@ -1,3 +1,4 @@
+import { Injectable } from '@nestjs/common';
 import { Repository } from "typeorm";
 import { AppDataSource } from "../data-source";
 import { Release } from "../entities/release.entity";
@@ -5,6 +6,7 @@ import { getPagination, getPagingData } from "../helpers/pagination.helper";
 import { UUID } from "crypto";
 import { ReleasePagination } from "../types/models/release.types";
 
+@Injectable()
 export class ReleaseService {
     private releaseRepository: Repository<Release>;
 

--- a/api/src/services/user.service.ts
+++ b/api/src/services/user.service.ts
@@ -1,8 +1,10 @@
+import { Injectable } from '@nestjs/common';
 import { Repository } from 'typeorm';
 import { AppDataSource } from '../data-source';
 import { User } from '../entities/user.entity';
 import { UUID } from '../types/common.types';
 
+@Injectable()
 export class UserService {
   private userRepository: Repository<User>;
 

--- a/api/src/types/common.types.ts
+++ b/api/src/types/common.types.ts
@@ -1,1 +1,1 @@
-export { UUID } from 'crypto';
+export type UUID = string;


### PR DESCRIPTION
### Motivation
- Move the API to a NestJS application structure to leverage modules, DI, and built-in request lifecycle features for cleaner organization and security primitives. 
- Introduce centralized TypeORM and configuration setup to standardize database connection and environment handling. 
- Add authentication and authorization building blocks (JWT guard, roles guard, current user decorator) and resource controllers to support users, labels, artists, releases, and auth flows.

### Description
- Update `package.json` to run the Nest bootstrap (`main.ts`) and add NestJS dependencies (`@nestjs/*`, `rxjs`) and simplify the `build` script to `tsc`.
- Add `src/main.ts` and `src/app.module.ts` to initialize Nest, set global prefix, pipes, filters, CORS, and TypeORM configuration using environment variables and `AppDataSource` initialization. 
- Add common utilities and request-layer artifacts including `CurrentUser` decorator, `Roles` metadata decorator, `JwtAuthGuard`, `RolesGuard`, and `HttpExceptionFilter` to handle auth and error formatting. 
- Introduce resource modules and controllers for `auth`, `users`, `labels`, `artists`, and `releases`, implementing endpoints, validation, error handling, and JWT issuance/verification using `jsonwebtoken` and helper functions. 
- Mark service classes as injectable with `@Injectable()`, adjust `UUID` type to `string` in `src/types/common.types.ts`, and keep services using `AppDataSource` repositories and pagination helpers.

### Testing
- No automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699f03b07734832d810da998ea861e91)