### PR TITLE
Add lyrics CRUD + sync UI with audio timestamping and types

### DIFF
--- a/api/src/entities/lyrics.entity.ts
+++ b/api/src/entities/lyrics.entity.ts
@@ -7,7 +7,7 @@ import { UUID } from '../types/common.types';
 export class Lyrics extends AbstractEntity {
   // CONTENT
   @Column({ type: 'jsonb' })
-  content: { time?: string; text: string }[];
+  content: { time?: number; text: string }[];
 
   // TRACK ID
   @Column({ name: 'track_id', nullable: false, type: 'uuid' })

--- a/api/src/modules/lyrics/lyrics.controller.ts
+++ b/api/src/modules/lyrics/lyrics.controller.ts
@@ -3,6 +3,7 @@ import {
   Controller,
   Get,
   Param,
+  Patch,
   Post,
   Query,
   UseGuards,
@@ -35,7 +36,14 @@ export class LyricsController {
 
   @Get(':id')
   async getLyricsById(@Param('id') id: string) {
-    const lyrics = await this.lyricsService.getLyricsById(id);
+    const lyrics = await this.lyricsService.getLyricsById(id as any);
     return { message: 'Lyrics fetched successfully', data: lyrics };
   }
+
+  @Patch(':id')
+  async updateLyrics(@Param('id') id: string, @Body() body: Partial<Lyrics>) {
+    const lyrics = await this.lyricsService.updateLyrics(id as any, body);
+    return { message: 'Lyrics updated successfully', data: lyrics };
+  }
 }
+

--- a/api/src/modules/lyrics/lyrics.service.ts
+++ b/api/src/modules/lyrics/lyrics.service.ts
@@ -24,7 +24,12 @@ export class LyricsService {
     page: number,
   ): Promise<Pagination> {
     const { take, skip } = getPagination({ size, page });
-    const lyrics = await this.lyricsRepository.findAndCount({ where: condition, take, skip });
+    const lyrics = await this.lyricsRepository.findAndCount({
+      where: condition,
+      order: { createdAt: 'DESC' },
+      take,
+      skip,
+    });
     return getPagingData({ data: lyrics, size, page });
   }
 
@@ -34,4 +39,12 @@ export class LyricsService {
     if (!lyrics) throw new NotFoundException('Lyrics not found');
     return lyrics;
   }
+
+  // UPDATE LYRICS
+  async updateLyrics(id: UUID, payload: Partial<Lyrics>): Promise<Lyrics> {
+    const lyrics = await this.getLyricsById(id);
+    Object.assign(lyrics, payload);
+    return this.lyricsRepository.save(lyrics);
+  }
 }
+

--- a/api/src/modules/tracks/tracks-query.service.ts
+++ b/api/src/modules/tracks/tracks-query.service.ts
@@ -52,7 +52,7 @@ export class TrackQueryService {
     return this.normalizeTrack(
       await this.trackRepository.findOne({
         where: { id },
-        relations: ["audioFiles", "trackContributors", "trackContributors.contributor"],
+        relations: ["audioFiles", "lyrics", "trackContributors", "trackContributors.contributor"],
       }),
     );
   }

--- a/client/src/pages/lyrics/CreateLyrics.tsx
+++ b/client/src/pages/lyrics/CreateLyrics.tsx
@@ -1,128 +1,193 @@
-import store from 'store';
 import { InputErrorMessage } from '@/components/feedbacks/ErrorLabels';
 import Button from '@/components/inputs/Button';
 import CustomTooltip from '@/components/inputs/CustomTooltip';
 import Input from '@/components/inputs/Input';
 import TextArea from '@/components/inputs/TextArea';
-import { Heading } from '@/components/text/Headings';
+import { Heading, RelaxedHeading } from '@/components/text/Headings';
 import UserLayout from '@/containers/UserLayout';
 import { useValidateLyrics } from '@/hooks/lyrics/lyrics.hooks';
+import { useGetTrack } from '@/hooks/tracks/track.hooks';
 import { setLyricsGuideLinesModal } from '@/state/features/lyricSlice';
+import { useCreateLyricsMutation } from '@/state/api/apiMutationSlice';
 import { AppDispatch } from '@/state/store';
 import { faCircleInfo } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { Controller, FieldValues, useForm } from 'react-hook-form';
+import { ChangeEvent, useEffect } from 'react';
+import { Controller, SubmitHandler, useForm } from 'react-hook-form';
 import { useDispatch } from 'react-redux';
-import { useNavigate } from 'react-router-dom';
-const CreateLyrics = () => {
-  // STATE VARIABLES
-  const dispatch: AppDispatch = useDispatch();
+import { useNavigate, useSearchParams } from 'react-router-dom';
+import { toast } from 'sonner';
 
-  // REACT HOOK FORM
+type CreateLyricsFormValues = {
+  trackId: string;
+  language: string;
+  content: string;
+};
+
+const defaultValues: CreateLyricsFormValues = {
+  trackId: '',
+  language: 'en',
+  content: '',
+};
+
+const CreateLyrics = () => {
+  const dispatch: AppDispatch = useDispatch();
+  const navigate = useNavigate();
+  const [searchParams] = useSearchParams();
+  const trackIdFromQuery = searchParams.get('trackId') ?? '';
+  const { getTrack, data: trackResponse } = useGetTrack();
+  const [createLyrics, { isLoading }] = useCreateLyricsMutation();
+
   const {
     control,
     handleSubmit,
+    setValue,
     formState: { errors },
-  } = useForm();
+  } = useForm<CreateLyricsFormValues>({
+    defaultValues: {
+      ...defaultValues,
+      trackId: trackIdFromQuery,
+    },
+  });
 
-  // NAVIGATION
-  const navigate = useNavigate();
+  useEffect(() => {
+    if (trackIdFromQuery) {
+      setValue('trackId', trackIdFromQuery);
+      void getTrack({ id: trackIdFromQuery });
+    }
+  }, [getTrack, setValue, trackIdFromQuery]);
 
-  // HANDLE SUBMIT
-  const onSubmit = (data: FieldValues) => {
-    const formattedLyrics: { title: string; content: string } = {
-      title: data.title,
-      content: data.content
-        .split('\n')
-        .map((line: string) =>
-          line.length > 70 ? line.slice(0, 70) + '\n' + line.slice(70) : line
-        )
-        .join('\n'),
-    };
-    store.set('lyrics', JSON.stringify(formattedLyrics));
-    navigate('/lyrics/sync');
-  };
-
-  // VALIDATE LYRICS
   const { errors: validateErrors, validateLyrics } = useValidateLyrics();
+
+  const onSubmit: SubmitHandler<CreateLyricsFormValues> = async (data) => {
+    try {
+      const payload = {
+        trackId: data.trackId.trim(),
+        language: data.language.trim() || 'en',
+        content: data.content
+          .split('\n')
+          .map((line) => ({ text: line.trim() })),
+      };
+      const response = await createLyrics(payload).unwrap();
+      toast.success('Lyrics created successfully.');
+      navigate(`/lyrics/sync?trackId=${payload.trackId}&lyricsId=${response.data.id}`);
+    } catch (error) {
+      const errorMessage =
+        (error as { data?: { message?: string } })?.data?.message ||
+        'Unable to create lyrics.';
+      toast.error(errorMessage);
+    }
+  };
 
   return (
     <UserLayout>
-      <main className="w-full flex flex-col gap-4">
-        <nav className="w-full flex items-center gap-3 justify-center">
-          <ul className="flex items-center gap-3">
-            <Heading>Create lyrics</Heading>
+      <main className="flex w-full flex-col gap-5">
+        <header className="rounded-md border border-gray-200/80 bg-white p-5 shadow-sm">
+          <div className="flex flex-wrap items-start justify-between gap-3">
+            <div className="space-y-1">
+              <RelaxedHeading>Lyrics</RelaxedHeading>
+              <Heading className="!text-gray-900">Create lyrics record</Heading>
+              <p className="text-[12px] text-gray-500">
+                Create a track-linked lyrics record before syncing it against the
+                uploaded primary audio.
+              </p>
+            </div>
             <CustomTooltip label="Lyrics guidelines">
-              <FontAwesomeIcon
-                onClick={(e) => {
-                  e.preventDefault();
-                  dispatch(setLyricsGuideLinesModal(true));
-                }}
-                icon={faCircleInfo}
-                className="text-primary cursor-pointer"
-              />
+              <button
+                type="button"
+                className="rounded-full border border-gray-200 p-2 text-primary transition-colors hover:bg-gray-50"
+                onClick={() => dispatch(setLyricsGuideLinesModal(true))}
+              >
+                <FontAwesomeIcon icon={faCircleInfo} />
+              </button>
             </CustomTooltip>
-          </ul>
-        </nav>
-        <form
-          className="w-[80%] mx-auto flex flex-col gap-5"
-          onSubmit={handleSubmit(onSubmit)}
-        >
-          <fieldset className="w-full flex flex-col gap-2">
-            <Controller
-              name="title"
-              control={control}
-              rules={{ required: 'Title is required' }}
-              render={({ field }) => (
-                <label className="w-full flex flex-col gap-1">
-                  <Input
-                    {...field}
-                    placeholder="Enter the title"
-                    label="Title"
-                  />
-                  {errors.title && (
-                    <InputErrorMessage message={errors.title.message} />
-                  )}
-                </label>
-              )}
-            />
-            <Controller
-              name="content"
-              control={control}
-              rules={{ required: 'Content is required' }}
-              render={({ field }) => (
-                <label className="w-full flex flex-col gap-1">
-                  <TextArea
-                    resize
-                    {...field}
-                    placeholder="Enter the content"
-                    label="Content"
-                    onChange={(e) => {
-                      field.onChange(e);
-                      validateLyrics(e.target.value);
-                    }}
-                  />
-                  {errors.content && (
-                    <InputErrorMessage message={errors.content.message} />
-                  )}
-                </label>
-              )}
-            />
-          </fieldset>
-          {validateErrors?.length > 0 && (
-            <ul className="w-full flex flex-col gap-1">
-              {validateErrors.map((error, index) => (
-                <li key={index} className="text-red-500">
-                  {error}
-                </li>
-              ))}
-            </ul>
-          )}
-          <menu className="w-full flex items-center gap-2 justify-end">
-            <Button primary submit>
-              Create
+          </div>
+        </header>
+
+        <form className="flex flex-col gap-4" onSubmit={handleSubmit(onSubmit)}>
+          <section className="rounded-md border border-gray-200/80 bg-white p-5 shadow-sm">
+            <header className="mb-4 space-y-1">
+              <Heading type="h3" className="!text-gray-900">
+                Record details
+              </Heading>
+              <p className="text-[12px] text-gray-500">
+                {trackResponse?.data?.title
+                  ? `Creating lyrics for ${trackResponse.data.title}.`
+                  : 'Associate the lyrics with a track and add the base text.'}
+              </p>
+            </header>
+
+            <div className="grid gap-4 md:grid-cols-2">
+              <Controller
+                name="trackId"
+                control={control}
+                rules={{ required: 'Track ID is required' }}
+                render={({ field }) => (
+                  <label className="flex flex-col gap-1">
+                    <Input {...field} label="Track ID" placeholder="Enter track ID" />
+                    {errors.trackId && (
+                      <InputErrorMessage message={errors.trackId.message} />
+                    )}
+                  </label>
+                )}
+              />
+
+              <Controller
+                name="language"
+                control={control}
+                rules={{ required: 'Language is required' }}
+                render={({ field }) => (
+                  <label className="flex flex-col gap-1">
+                    <Input {...field} label="Language" placeholder="en" />
+                    {errors.language && (
+                      <InputErrorMessage message={errors.language.message} />
+                    )}
+                  </label>
+                )}
+              />
+            </div>
+
+            <div className="mt-4">
+              <Controller
+                name="content"
+                control={control}
+                rules={{ required: 'Lyrics content is required' }}
+                render={({ field }) => (
+                  <label className="flex flex-col gap-1">
+                    <TextArea
+                      resize
+                      {...field}
+                      rows={12}
+                      label="Lyrics"
+                      placeholder="Enter one lyric line per row"
+                      onChange={(event: ChangeEvent<HTMLTextAreaElement>) => {
+                        field.onChange(event);
+                        validateLyrics(event.target.value);
+                      }}
+                    />
+                    {errors.content && (
+                      <InputErrorMessage message={errors.content.message} />
+                    )}
+                  </label>
+                )}
+              />
+            </div>
+
+            {validateErrors.length > 0 && (
+              <ul className="mt-4 flex flex-col gap-2 rounded-md border border-red-200 bg-red-50/70 p-4 text-[12px] text-red-700">
+                {validateErrors.map((error, index) => (
+                  <li key={`${error}-${index}`}>{error}</li>
+                ))}
+              </ul>
+            )}
+          </section>
+
+          <footer className="flex items-center justify-end gap-3">
+            <Button route="/lyrics">Cancel</Button>
+            <Button primary submit isLoading={isLoading}>
+              Create and sync
             </Button>
-          </menu>
+          </footer>
         </form>
       </main>
     </UserLayout>

--- a/client/src/pages/lyrics/SyncLyrics.tsx
+++ b/client/src/pages/lyrics/SyncLyrics.tsx
@@ -1,30 +1,168 @@
-import { useState, useRef, useEffect, useMemo, useCallback } from 'react';
-import store from 'store';
-import UserLayout from '@/containers/UserLayout';
-import { Heading } from '@/components/text/Headings';
-import { Button as UIButton } from '@/components/ui/button';
-import Input from '@/components/inputs/Input';
-import { Link } from 'react-router-dom';
 import Button from '@/components/inputs/Button';
+import { Heading, RelaxedHeading } from '@/components/text/Headings';
+import UserLayout from '@/containers/UserLayout';
+import { useGetTrack } from '@/hooks/tracks/track.hooks';
+import {
+  useCreateLyricsMutation,
+  useUpdateLyricsMutation,
+} from '@/state/api/apiMutationSlice';
+import {
+  useLazyFetchLyricsQuery,
+  useLazyGetLyricsQuery,
+} from '@/state/api/apiQuerySlice';
+import type {
+  AudioFile,
+  TimedLyricLine,
+  Track,
+  TrackLyrics,
+} from '@/types/models/track.types';
+import { faArrowRotateLeft, faClosedCaptioning, faPlus, faSave } from '@fortawesome/free-solid-svg-icons';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { ChangeEvent, KeyboardEvent as ReactKeyboardEvent, useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useSearchParams } from 'react-router-dom';
+import { toast } from 'sonner';
+
+type SyncStateLine = {
+  index: number;
+  text: string;
+  time?: number;
+};
+
+const formatSyncLabel = (lyrics: TrackLyrics) => {
+  const createdAt = lyrics.createdAt
+    ? new Date(lyrics.createdAt).toLocaleDateString()
+    : 'Draft';
+  return `${lyrics.language.toUpperCase()} · ${createdAt}`;
+};
+
+const sortLyricsByNewest = (lyrics: TrackLyrics[]) =>
+  [...lyrics].sort(
+    (first, second) =>
+      new Date(second.createdAt).getTime() - new Date(first.createdAt).getTime(),
+  );
+
+const toSyncLines = (content: TimedLyricLine[]): SyncStateLine[] =>
+  content.map((line, index) => ({
+    index,
+    text: line.text,
+    time: typeof line.time === 'number' ? line.time : undefined,
+  }));
 
 const SyncLyrics = () => {
-  // STATE VARIABLES
-  const [lyricsData] = useState(
-    store.get('lyrics')
-      ? JSON.parse(store.get('lyrics'))
-      : { title: '', content: '' }
-  );
-  const [audio, setAudio] = useState(null);
-  const [isPlaying, setIsPlaying] = useState(false);
-  const [currentTime, setCurrentTime] = useState(0);
-  const [syncedLyrics, setSyncedLyrics] = useState<
-    {
-      time: number;
-      line: string;
-      index: number;
-    }[]
-  >([]);
+  const [searchParams, setSearchParams] = useSearchParams();
+  const trackId = searchParams.get('trackId') ?? '';
+  const lyricsId = searchParams.get('lyricsId') ?? '';
+
+  const { getTrack, data: trackResponse, isFetching: trackIsFetching } = useGetTrack();
+  const [fetchLyrics, { data: lyricsResponse, isFetching: lyricsAreFetching }] =
+    useLazyFetchLyricsQuery();
+  const [getLyrics, { isFetching: lyricsRecordIsFetching }] = useLazyGetLyricsQuery();
+  const [createLyrics, { isLoading: isCreatingLyrics }] = useCreateLyricsMutation();
+  const [updateLyrics, { isLoading: isUpdatingLyrics }] = useUpdateLyricsMutation();
+
+  const [selectedLyricsId, setSelectedLyricsId] = useState(lyricsId);
+  const [editorLanguage, setEditorLanguage] = useState('en');
+  const [plainTextLyrics, setPlainTextLyrics] = useState('');
+  const [syncState, setSyncState] = useState<SyncStateLine[]>([]);
   const [currentLineIndex, setCurrentLineIndex] = useState(0);
+  const [currentTime, setCurrentTime] = useState(0);
+  const [isPlaying, setIsPlaying] = useState(false);
+
+  const audioRef = useRef<HTMLAudioElement | null>(null);
+  const lyricsRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    setSelectedLyricsId(lyricsId);
+  }, [lyricsId]);
+
+  useEffect(() => {
+    if (trackId) {
+      void getTrack({ id: trackId });
+      void fetchLyrics({ trackId, size: 100, page: 0 });
+    }
+  }, [fetchLyrics, getTrack, trackId]);
+
+  const track = trackResponse?.data as Track | undefined;
+  const lyricsRecords = useMemo<TrackLyrics[]>(() => {
+    const rows = (lyricsResponse?.data?.rows ?? []) as TrackLyrics[];
+    return sortLyricsByNewest(rows);
+  }, [lyricsResponse?.data?.rows]);
+
+  useEffect(() => {
+    if (!lyricsId && !selectedLyricsId && lyricsRecords.length > 0) {
+      const nextLyricsId = lyricsRecords[0].id;
+      setSelectedLyricsId(nextLyricsId);
+      setSearchParams((params) => {
+        params.set('trackId', trackId);
+        params.set('lyricsId', nextLyricsId);
+        return params;
+      });
+    }
+  }, [lyricsId, lyricsRecords, selectedLyricsId, setSearchParams, trackId]);
+
+  useEffect(() => {
+    if (!selectedLyricsId) {
+      setEditorLanguage(track?.primaryLanguage || 'en');
+      setPlainTextLyrics('');
+      setSyncState([]);
+      return;
+    }
+
+    const matchingRecord = lyricsRecords.find((record) => record.id === selectedLyricsId);
+    if (matchingRecord) {
+      setEditorLanguage(matchingRecord.language || track?.primaryLanguage || 'en');
+      setPlainTextLyrics(matchingRecord.content.map((line) => line.text).join('\n'));
+      setSyncState(toSyncLines(matchingRecord.content));
+      setCurrentLineIndex(0);
+      return;
+    }
+
+    void (async () => {
+      try {
+        const response = await getLyrics({ id: selectedLyricsId }).unwrap();
+        const fetchedLyrics = response.data as TrackLyrics;
+        setEditorLanguage(fetchedLyrics.language || track?.primaryLanguage || 'en');
+        setPlainTextLyrics(fetchedLyrics.content.map((line) => line.text).join('\n'));
+        setSyncState(toSyncLines(fetchedLyrics.content));
+        setCurrentLineIndex(0);
+      } catch (error) {
+        const errorMessage =
+          (error as { data?: { message?: string } })?.data?.message ||
+          'Unable to load the selected lyrics record.';
+        toast.error(errorMessage);
+      }
+    })();
+  }, [getLyrics, lyricsRecords, selectedLyricsId, track?.primaryLanguage]);
+
+  const primaryAudio = useMemo<AudioFile | undefined>(
+    () => track?.audioFiles?.find((audioFile) => audioFile.isPrimary) ?? track?.audioFiles?.[0],
+    [track?.audioFiles],
+  );
+
+  const lyricLines = useMemo(
+    () => plainTextLyrics.split('\n').map((line) => line.trimEnd()),
+    [plainTextLyrics],
+  );
+
+  useEffect(() => {
+    setSyncState((previousState) =>
+      lyricLines.map((line, index) => {
+        const existingLine = previousState.find((item) => item.index === index);
+        return {
+          index,
+          text: line,
+          time: existingLine?.time,
+        };
+      }),
+    );
+
+    setCurrentLineIndex((previousIndex) => {
+      if (lyricLines.length === 0) {
+        return 0;
+      }
+      return Math.min(previousIndex, lyricLines.length - 1);
+    });
+  }, [lyricLines]);
 
   const handleTimeUpdate = useCallback(() => {
     if (audioRef.current) {
@@ -32,178 +170,453 @@ const SyncLyrics = () => {
     }
   }, []);
 
-  const handleSync = useCallback(
-    (line: string, index: number) => {
-      setSyncedLyrics((prev) => {
-        const newSyncedLyrics = prev.filter((item) => item.index !== index);
-        return [...newSyncedLyrics, { time: currentTime, line, index }].sort(
-          (a, b) => a.index - b.index
-        );
-      });
-    },
-    [currentTime]
-  );
-
-  const audioRef = useRef(null);
-  const lyricsRef = useRef(null);
-
-  const splitLyrics = useMemo(
-    () => lyricsData.content.split('\n'),
-    [lyricsData.content]
-  );
-
-  const handleKeyDown = useCallback(
-    (event: KeyboardEvent) => {
-      if (event.code === 'ArrowUp' && currentLineIndex > 0) {
-        setCurrentLineIndex((prev) => prev - 1);
-      } else if (
-        event.code === 'ArrowDown' &&
-        currentLineIndex < splitLyrics.length - 1
-      ) {
-        setCurrentLineIndex((prev) => prev + 1);
-      } else if (event.code === 'Space' && isPlaying) {
-        event.preventDefault();
-        const currentLine = splitLyrics[currentLineIndex];
-        handleSync(currentLine, currentLineIndex);
-      }
-    },
-    [currentLineIndex, splitLyrics, isPlaying, handleSync]
-  );
-
   useEffect(() => {
-    if (audioRef.current) {
-      audioRef.current.addEventListener('timeupdate', handleTimeUpdate);
+    const audioElement = audioRef.current;
+    if (!audioElement) {
+      return undefined;
     }
-    document.addEventListener('keydown', handleKeyDown);
+
+    const handlePause = () => setIsPlaying(false);
+    const handlePlay = () => setIsPlaying(true);
+
+    audioElement.addEventListener('timeupdate', handleTimeUpdate);
+    audioElement.addEventListener('pause', handlePause);
+    audioElement.addEventListener('play', handlePlay);
+
     return () => {
-      if (audioRef.current) {
-        audioRef.current.removeEventListener('timeupdate', handleTimeUpdate);
-      }
-      document.removeEventListener('keydown', handleKeyDown);
+      audioElement.removeEventListener('timeupdate', handleTimeUpdate);
+      audioElement.removeEventListener('pause', handlePause);
+      audioElement.removeEventListener('play', handlePlay);
     };
-  }, [currentLineIndex, isPlaying, handleTimeUpdate, handleKeyDown]);
-
-  const handleFileUpload = (event) => {
-    const file = event.target.files[0];
-    const url = URL.createObjectURL(file);
-    setAudio(url);
-  };
-
-  const handlePlay = () => {
-    if (audioRef.current) {
-      if (isPlaying) {
-        audioRef.current.pause();
-      } else {
-        audioRef.current.play();
-      }
-      setIsPlaying(!isPlaying);
-    }
-  };
+  }, [handleTimeUpdate]);
 
   useEffect(() => {
-    if (lyricsRef.current) {
-      const lineElements = lyricsRef.current.children;
-      if (lineElements[currentLineIndex]) {
-        lineElements[currentLineIndex].scrollIntoView({
-          behavior: 'smooth',
-          block: 'center',
-        });
-      }
+    if (!lyricsRef.current) {
+      return;
+    }
+    const lineElements = lyricsRef.current.children;
+    if (lineElements[currentLineIndex] instanceof HTMLElement) {
+      lineElements[currentLineIndex].scrollIntoView({
+        behavior: 'smooth',
+        block: 'center',
+      });
     }
   }, [currentLineIndex]);
 
+  const handleSync = useCallback(
+    (index: number) => {
+      const nextLine = lyricLines[index] ?? '';
+      setSyncState((previousState) =>
+        previousState.map((line) =>
+          line.index === index
+            ? {
+                ...line,
+                text: nextLine,
+                time: Number(currentTime.toFixed(2)),
+              }
+            : line,
+        ),
+      );
+    },
+    [currentTime, lyricLines],
+  );
+
+  const handleResetLine = useCallback((index: number) => {
+    setSyncState((previousState) =>
+      previousState.map((line) =>
+        line.index === index
+          ? {
+              ...line,
+              time: undefined,
+            }
+          : line,
+      ),
+    );
+  }, []);
+
+  const handleEditorKeyDown = useCallback(
+    (event: ReactKeyboardEvent<HTMLTextAreaElement>) => {
+      if (event.key === 'ArrowUp') {
+        setCurrentLineIndex((previousIndex) => Math.max(previousIndex - 1, 0));
+      }
+
+      if (event.key === 'ArrowDown') {
+        setCurrentLineIndex((previousIndex) =>
+          Math.min(previousIndex + 1, Math.max(lyricLines.length - 1, 0)),
+        );
+      }
+    },
+    [lyricLines.length],
+  );
+
+  useEffect(() => {
+    const handleWindowKeyDown = (event: KeyboardEvent) => {
+      if (event.code === 'ArrowUp') {
+        setCurrentLineIndex((previousIndex) => Math.max(previousIndex - 1, 0));
+      } else if (event.code === 'ArrowDown') {
+        setCurrentLineIndex((previousIndex) =>
+          Math.min(previousIndex + 1, Math.max(lyricLines.length - 1, 0)),
+        );
+      } else if (event.code === 'Space' && isPlaying) {
+        event.preventDefault();
+        handleSync(currentLineIndex);
+      }
+    };
+
+    window.addEventListener('keydown', handleWindowKeyDown);
+    return () => window.removeEventListener('keydown', handleWindowKeyDown);
+  }, [currentLineIndex, handleSync, isPlaying, lyricLines.length]);
+
+  const handlePlayToggle = async () => {
+    if (!audioRef.current) {
+      return;
+    }
+
+    try {
+      if (audioRef.current.paused) {
+        await audioRef.current.play();
+        setIsPlaying(true);
+      } else {
+        audioRef.current.pause();
+        setIsPlaying(false);
+      }
+    } catch {
+      toast.error('Unable to start audio playback.');
+    }
+  };
+
+  const handleLyricsRecordChange = (event: ChangeEvent<HTMLSelectElement>) => {
+    const nextLyricsId = event.target.value;
+    setSelectedLyricsId(nextLyricsId);
+    setSearchParams((params) => {
+      params.set('trackId', trackId);
+      params.set('lyricsId', nextLyricsId);
+      return params;
+    });
+  };
+
+  const handleSave = async () => {
+    if (!trackId) {
+      toast.error('Track ID is required to save synced lyrics.');
+      return;
+    }
+
+    const payload = {
+      trackId,
+      language: editorLanguage.trim() || track?.primaryLanguage || 'en',
+      content: syncState.map((line) => ({
+        text: line.text,
+        ...(typeof line.time === 'number' ? { time: line.time } : {}),
+      })),
+    };
+
+    try {
+      if (selectedLyricsId) {
+        await updateLyrics({ id: selectedLyricsId, body: payload }).unwrap();
+        toast.success('Lyrics sync updated successfully.');
+      } else {
+        const response = await createLyrics(payload).unwrap();
+        const createdLyrics = response.data as TrackLyrics;
+        toast.success('Lyrics sync created successfully.');
+        setSelectedLyricsId(createdLyrics.id);
+        setSearchParams((params) => {
+          params.set('trackId', trackId);
+          params.set('lyricsId', createdLyrics.id);
+          return params;
+        });
+      }
+      await fetchLyrics({ trackId, size: 100, page: 0 });
+    } catch (error) {
+      const errorMessage =
+        (error as { data?: { message?: string } })?.data?.message ||
+        'Unable to save synced lyrics.';
+      toast.error(errorMessage);
+    }
+  };
+
+  const isBusy =
+    trackIsFetching ||
+    lyricsAreFetching ||
+    lyricsRecordIsFetching ||
+    isCreatingLyrics ||
+    isUpdatingLyrics;
+
+  if (!trackId) {
+    return (
+      <UserLayout>
+        <main className="flex w-full flex-col gap-4">
+          <section className="rounded-md border border-dashed border-gray-300 bg-white p-8 text-center shadow-sm">
+            <Heading className="!text-gray-900">Track required</Heading>
+            <p className="mt-3 text-[12px] text-gray-500">
+              Open lyrics sync from a track page so the editor can load the
+              uploaded primary audio.
+            </p>
+            <div className="mt-4 flex justify-center">
+              <Button route="/lyrics">Back to lyrics</Button>
+            </div>
+          </section>
+        </main>
+      </UserLayout>
+    );
+  }
+
   return (
     <UserLayout>
-      <main className="w-full flex flex-col gap-4">
-        <nav className="w-full flex flex-col items-center gap-3 justify-center">
-          <ul className="flex items-center gap-3">
-            <Heading>Lyrics</Heading>
-            <li>
-              <Input type="file" accept="audio/*" onChange={handleFileUpload} />
-            </li>
-            <li>
-              <UIButton
-                variant={`outline-solid`}
-                className="text-[13px] p-1 px-4"
-                onClick={handlePlay}
+      <main className="flex w-full flex-col gap-4">
+        <header className="rounded-md border border-gray-200/80 bg-white p-5 shadow-sm">
+          <div className="flex flex-wrap items-start justify-between gap-4">
+            <div className="space-y-1">
+              <RelaxedHeading>Lyrics sync</RelaxedHeading>
+              <Heading className="!text-gray-900">
+                {track?.title || 'Track lyrics sync'}
+              </Heading>
+              <p className="text-[12px] text-gray-500">
+                Sync lyrics against the uploaded primary audio and overwrite the
+                selected lyrics record when you save.
+              </p>
+            </div>
+            <div className="flex flex-wrap items-center gap-2">
+              <Button
+                icon={faPlus}
+                route={`/lyrics/create?trackId=${trackId}`}
               >
-                {isPlaying ? 'Pause' : 'Play'}
-              </UIButton>
-            </li>
-          </ul>
-        </nav>
-        <section className="flex items-center justify-center w-[80%] mx-auto flex-col gap-4">
-          <h1 className="text-2xl font-bold">{lyricsData.title}</h1>
-          <article
-            ref={lyricsRef}
-            className="text-md flex flex-col gap-1 text-gray-500 text-left w-full max-h-[70vh] overflow-y-auto p-4"
-          >
-            {splitLyrics.map((line: string, index: number) => {
-              const lyricLine = syncedLyrics.find(
-                (item) => item.index === index
-              );
-              return (
-                <section
-                  key={index}
-                  className={`flex justify-between items-center mb-2 w-full ${
-                    index === currentLineIndex ? 'bg-gray-100' : ''
-                  }`}
-                >
-                  <Link
-                    to={`#`}
-                    onClick={(e) => {
-                      e.preventDefault();
-                      setCurrentLineIndex(index);
-                    }}
-                    className="flex items-center gap-2 hover:bg-background p-1 px-2 rounded-md w-full cursor-pointer"
-                  >
-                    {lyricLine && (
-                      <span className="text-sm text-primary font-medium">
-                        {lyricLine.time.toFixed(2)}s
-                      </span>
-                    )}
-                    <p
-                      className={`${
-                        syncedLyrics.some((item) => item.index === index)
-                          ? 'text-black font-medium'
-                          : 'text-gray-500'
-                      } hover:text-black`}
-                    >
-                      {line}
-                    </p>
-                  </Link>
-                  <UIButton
-                    variant="outline"
-                    size="sm"
-                    onClick={() => handleSync(line, index)}
-                    disabled={!audio || !isPlaying}
-                  >
-                    Sync
-                  </UIButton>
-                </section>
-              );
-            })}
-            <menu
-              className="w-full flex items-center justify-end mt-5"
-              onClick={(e) => {
-                e.preventDefault();
-                console.log(
-                  syncedLyrics?.map((item) => {
-                    return {
-                      time: item?.time,
-                      text: item?.line,
-                    };
-                  })
-                );
-              }}
-            >
-              <Button primary className="self-end">
-                Save
+                New lyrics record
               </Button>
-            </menu>
-          </article>
-        </section>
-        {audio && <audio ref={audioRef} src={audio} />}
+              <Button
+                primary
+                icon={faSave}
+                onClick={(event) => {
+                  event.preventDefault();
+                  void handleSave();
+                }}
+                isLoading={isBusy}
+              >
+                Save sync
+              </Button>
+            </div>
+          </div>
+        </header>
+
+        {!primaryAudio ? (
+          <section className="rounded-md border border-dashed border-gray-300 bg-white p-8 text-center shadow-sm">
+            <Heading className="!text-gray-900">Primary audio required</Heading>
+            <p className="mt-3 text-[12px] text-gray-500">
+              Upload track audio before syncing lyrics. The sync timeline uses the
+              track&apos;s uploaded primary audio source.
+            </p>
+            <div className="mt-4 flex justify-center">
+              <Button
+                route={`/releases/${track?.releaseId}/manage-tracks/${trackId}`}
+              >
+                Back to track editor
+              </Button>
+            </div>
+          </section>
+        ) : (
+          <section className="grid gap-4 xl:grid-cols-[minmax(0,1.75fr)_360px]">
+            <article className="flex flex-col gap-4">
+              <section className="rounded-md border border-gray-200/80 bg-white p-5 shadow-sm">
+                <header className="flex flex-wrap items-center justify-between gap-3">
+                  <div>
+                    <Heading type="h3" className="!text-gray-900">
+                      Audio reference
+                    </Heading>
+                    <p className="text-[12px] text-gray-500">
+                      Primary uploaded audio · {primaryAudio.fileType}
+                    </p>
+                  </div>
+                  <div className="flex items-center gap-2">
+                    <Button
+                      icon={faClosedCaptioning}
+                      onClick={(event) => {
+                        event.preventDefault();
+                        void handlePlayToggle();
+                      }}
+                    >
+                      {isPlaying ? 'Pause' : 'Play'}
+                    </Button>
+                  </div>
+                </header>
+
+                <audio ref={audioRef} src={primaryAudio.storagePath} preload="metadata" className="mt-4 w-full" controls />
+
+                <dl className="mt-4 grid gap-3 rounded-md border border-gray-100 bg-gray-50/80 p-4 sm:grid-cols-3">
+                  <div>
+                    <dt className="text-[11px] uppercase tracking-[0.14em] text-gray-500">
+                      Current time
+                    </dt>
+                    <dd className="mt-1 text-sm text-gray-900">{currentTime.toFixed(2)}s</dd>
+                  </div>
+                  <div>
+                    <dt className="text-[11px] uppercase tracking-[0.14em] text-gray-500">
+                      Active line
+                    </dt>
+                    <dd className="mt-1 text-sm text-gray-900">{currentLineIndex + 1}</dd>
+                  </div>
+                  <div>
+                    <dt className="text-[11px] uppercase tracking-[0.14em] text-gray-500">
+                      Synced lines
+                    </dt>
+                    <dd className="mt-1 text-sm text-gray-900">
+                      {syncState.filter((line) => typeof line.time === 'number').length} / {syncState.length}
+                    </dd>
+                  </div>
+                </dl>
+              </section>
+
+              <section className="rounded-md border border-gray-200/80 bg-white p-5 shadow-sm">
+                <header className="flex flex-wrap items-center justify-between gap-3">
+                  <div>
+                    <Heading type="h3" className="!text-gray-900">
+                      Lyrics lines
+                    </Heading>
+                    <p className="text-[12px] text-gray-500">
+                      Use ↑ and ↓ to move between lines, then press Space while
+                      the audio is playing to capture a timestamp.
+                    </p>
+                  </div>
+                  <button
+                    type="button"
+                    className="inline-flex items-center gap-2 text-[12px] text-[color:var(--lens-blue)] transition-colors hover:opacity-80"
+                    onClick={() => {
+                      setCurrentLineIndex(0);
+                      if (audioRef.current) {
+                        audioRef.current.currentTime = 0;
+                        setCurrentTime(0);
+                      }
+                    }}
+                  >
+                    <FontAwesomeIcon icon={faArrowRotateLeft} />
+                    Reset playhead
+                  </button>
+                </header>
+
+                <div ref={lyricsRef} className="mt-4 flex max-h-[65vh] flex-col gap-3 overflow-y-auto">
+                  {syncState.map((line) => {
+                    const isActive = line.index === currentLineIndex;
+                    const isSynced = typeof line.time === 'number';
+
+                    return (
+                      <section
+                        key={`${line.index}-${line.text}`}
+                        className={`rounded-md border p-3 transition-colors ${
+                          isActive
+                            ? 'border-[color:var(--lens-blue)] bg-[color:var(--lens-blue)]/5'
+                            : 'border-gray-100 bg-gray-50/80'
+                        }`}
+                      >
+                        <div className="flex flex-wrap items-center justify-between gap-3">
+                          <div className="space-y-1">
+                            <p className="text-[11px] uppercase tracking-[0.14em] text-gray-500">
+                              Line {line.index + 1}
+                            </p>
+                            <p className={`text-sm ${isSynced ? 'font-normal text-gray-900' : 'text-gray-600'}`}>
+                              {line.text || <span className="italic text-gray-400">Blank line</span>}
+                            </p>
+                          </div>
+                          <div className="flex flex-wrap items-center gap-2">
+                            <span className="min-w-16 text-right text-[12px] text-[color:var(--lens-blue)]">
+                              {typeof line.time === 'number' ? `${line.time.toFixed(2)}s` : 'Not synced'}
+                            </span>
+                            <button
+                              type="button"
+                              className="inline-flex h-9 items-center justify-center rounded-md border border-[color:var(--lens-blue)] px-3 text-[12px] text-[color:var(--lens-blue)] transition-colors hover:bg-[color:var(--lens-sand)]"
+                              onClick={() => {
+                                setCurrentLineIndex(line.index);
+                                handleSync(line.index);
+                              }}
+                              disabled={!isPlaying}
+                            >
+                              Sync now
+                            </button>
+                            <button
+                              type="button"
+                              className="inline-flex h-9 items-center justify-center rounded-md border border-gray-200 px-3 text-[12px] text-gray-600 transition-colors hover:bg-gray-100"
+                              onClick={() => handleResetLine(line.index)}
+                            >
+                              Clear
+                            </button>
+                          </div>
+                        </div>
+                      </section>
+                    );
+                  })}
+                </div>
+              </section>
+            </article>
+
+            <aside className="flex flex-col gap-4">
+              <section className="rounded-md border border-gray-200/80 bg-white p-5 shadow-sm">
+                <header className="space-y-1">
+                  <Heading type="h3" className="!text-gray-900">
+                    Record selection
+                  </Heading>
+                  <p className="text-[12px] text-gray-500">
+                    Multiple lyrics records can exist per track. Saving overwrites
+                    the currently selected record.
+                  </p>
+                </header>
+
+                <label className="mt-4 flex flex-col gap-2">
+                  <span className="text-[12px] text-[color:var(--lens-ink)]">Lyrics record</span>
+                  <select
+                    className="h-10 rounded-lg border border-secondary/40 bg-white px-3 text-[12px]"
+                    value={selectedLyricsId}
+                    onChange={handleLyricsRecordChange}
+                    disabled={lyricsRecords.length === 0}
+                  >
+                    {lyricsRecords.length === 0 ? (
+                      <option value="">No lyrics records yet</option>
+                    ) : (
+                      lyricsRecords.map((lyrics) => (
+                        <option key={lyrics.id} value={lyrics.id}>
+                          {formatSyncLabel(lyrics)}
+                        </option>
+                      ))
+                    )}
+                  </select>
+                </label>
+
+                <label className="mt-4 flex flex-col gap-2">
+                  <span className="text-[12px] text-[color:var(--lens-ink)]">Language</span>
+                  <input
+                    value={editorLanguage}
+                    onChange={(event) => setEditorLanguage(event.target.value)}
+                    className="h-10 rounded-lg border border-secondary/40 bg-white px-3 text-[12px]"
+                    placeholder="en"
+                  />
+                </label>
+              </section>
+
+              <section className="rounded-md border border-gray-200/80 bg-white p-5 shadow-sm">
+                <header className="space-y-1">
+                  <Heading type="h3" className="!text-gray-900">
+                    Lyrics editor
+                  </Heading>
+                  <p className="text-[12px] text-gray-500">
+                    Update the plain lyric lines here before syncing timestamps.
+                  </p>
+                </header>
+
+                <textarea
+                  value={plainTextLyrics}
+                  onChange={(event) => setPlainTextLyrics(event.target.value)}
+                  onKeyDown={handleEditorKeyDown}
+                  rows={18}
+                  className="mt-4 w-full rounded-md border border-gray-200 bg-gray-50/70 p-3 text-[13px] text-gray-900 outline-hidden transition-colors focus:border-[color:var(--lens-blue)]"
+                  placeholder="Enter one lyric line per row"
+                />
+              </section>
+
+              <section className="rounded-md border border-dashed border-gray-200 bg-gray-50/60 p-4 text-[12px] text-gray-500 shadow-sm">
+                <p>
+                  Tip: Keep the lyrics editor and sync list aligned by editing one
+                  line per row. Empty rows are preserved when saved.
+                </p>
+              </section>
+            </aside>
+          </section>
+        )}
       </main>
     </UserLayout>
   );

--- a/client/src/pages/tracks/ManageReleaseTrack.tsx
+++ b/client/src/pages/tracks/ManageReleaseTrack.tsx
@@ -367,6 +367,10 @@ const ManageReleaseTrack = () => {
             uploadFileName={uploadFileName}
             onAudioUpload={handleAudioUpload}
             onDeleteAudio={handleDeleteAudio}
+            onSyncLyrics={() => {
+              if (!trackId) return;
+              navigate(`/lyrics/sync?trackId=${trackId}`);
+            }}
           />
 
           <TrackContributorsPanel

--- a/client/src/pages/tracks/components/TrackAudioPanel.tsx
+++ b/client/src/pages/tracks/components/TrackAudioPanel.tsx
@@ -5,8 +5,8 @@ import { Track } from "@/types/models/track.types";
 import { formatDuration } from "./trackForm.helpers";
 import type { TrackAudioUploadPhase } from "@/hooks/tracks/useTrackAudioUpload";
 import TrackUploadProgress from "./TrackUploadProgress";
-import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import { faTrash } from "@fortawesome/free-solid-svg-icons";
+import { faClosedCaptioning } from "@fortawesome/free-solid-svg-icons";
+import Button from "@/components/inputs/Button";
 
 type TrackAudioPanelProps = {
   track?: Track;
@@ -18,6 +18,7 @@ type TrackAudioPanelProps = {
   uploadFileName: string;
   onAudioUpload: (event: ChangeEvent<HTMLInputElement>) => Promise<void>;
   onDeleteAudio: (audioFileId: string) => Promise<void>;
+  onSyncLyrics?: () => void;
 };
 
 const TrackAudioPanel = ({
@@ -30,106 +31,125 @@ const TrackAudioPanel = ({
   uploadFileName,
   onAudioUpload,
   onDeleteAudio,
-}: TrackAudioPanelProps) => (
-  <section className="rounded-md border border-[color:var(--lens-sand)]/70 bg-white p-4">
-    <header className="space-y-1">
-      <h2 className="text-sm font-normal text-[color:var(--lens-ink)]">Audio</h2>
-      <p className="text-[12px] text-[color:var(--lens-ink)]/55">
-        Uploading a new file makes it the primary audio.
-      </p>
-    </header>
+  onSyncLyrics,
+}: TrackAudioPanelProps) => {
+  const primaryAudio =
+    track?.audioFiles?.find((audioFile) => audioFile.isPrimary) ??
+    track?.audioFiles?.[0];
 
-    <dl className="mt-3 grid gap-2 rounded-md bg-[color:var(--lens-sand)]/10 p-3">
-      <figure className="flex items-center justify-between gap-3">
-        <dt className="text-[11px] uppercase tracking-[0.14em] text-[color:var(--lens-ink)]/50">
-          Duration
-        </dt>
-        <dd className="text-[12px] text-[color:var(--lens-ink)]">
-          {formatDuration(track?.durationMs)}
-        </dd>
-      </figure>
-      <figure className="flex items-center justify-between gap-3">
-        <dt className="text-[11px] uppercase tracking-[0.14em] text-[color:var(--lens-ink)]/50">
-          Status
-        </dt>
-        <dd className="text-[12px] text-[color:var(--lens-ink)]">
-          {capitalizeString(track?.status)}
-        </dd>
-      </figure>
-    </dl>
+  return (
+    <section className="rounded-md border border-[color:var(--lens-sand)]/70 bg-white p-4">
+      <header className="space-y-1">
+        <div className="flex items-start justify-between gap-3">
+          <div>
+            <h2 className="text-sm font-normal text-[color:var(--lens-ink)]">Audio</h2>
+            <p className="text-[12px] text-[color:var(--lens-ink)]/55">
+              Uploading a new file makes it the primary audio.
+            </p>
+          </div>
+          {primaryAudio && onSyncLyrics && (
+            <Button icon={faClosedCaptioning} onClick={(event) => {
+              event.preventDefault();
+              onSyncLyrics();
+            }}>
+              Sync lyrics
+            </Button>
+          )}
+        </div>
+      </header>
 
-    <fieldset className="mt-4 border-none p-0">
-      <Input
-        type="file"
-        label={track?.audioFiles?.length ? "Replace audio" : "Upload audio"}
-        accept="audio/*"
-        onChange={(event) => void onAudioUpload(event)}
-        readOnly={isUploadingAudio}
-      />
-      <TrackUploadProgress
-        progress={uploadProgress}
-        phase={uploadPhase}
-        isUploading={isUploadingAudio}
-        isComplete={isUploadComplete}
-        fileName={uploadFileName}
-      />
-      {isDeletingAudio && (
-        <p className="mt-2 text-[12px] text-[color:var(--lens-ink)]/55">
-          Updating audio...
-        </p>
-      )}
-    </fieldset>
+      <dl className="mt-3 grid gap-2 rounded-md bg-[color:var(--lens-sand)]/10 p-3">
+        <div className="flex items-center justify-between gap-3">
+          <dt className="text-[11px] uppercase tracking-[0.14em] text-[color:var(--lens-ink)]/50">
+            Duration
+          </dt>
+          <dd className="text-[12px] text-[color:var(--lens-ink)]">
+            {formatDuration(track?.durationMs)}
+          </dd>
+        </div>
+        <div className="flex items-center justify-between gap-3">
+          <dt className="text-[11px] uppercase tracking-[0.14em] text-[color:var(--lens-ink)]/50">
+            Status
+          </dt>
+          <dd className="text-[12px] text-[color:var(--lens-ink)]">
+            {capitalizeString(track?.status)}
+          </dd>
+        </div>
+      </dl>
 
-    <ul className="mt-4 flex list-none flex-col gap-2 p-0">
-      {track?.audioFiles?.length ? (
-        track.audioFiles.map((audioFile) => (
-          <li
-            key={audioFile.id}
-            className="rounded-md border border-[color:var(--lens-sand)]/70 p-3"
-          >
-            <header className="flex items-start justify-between gap-3">
-              <section className="space-y-1">
-                <p className="text-[12px] font-normal text-[color:var(--lens-ink)]">
-                  {audioFile.fileType}
-                </p>
-                <p className="text-[11px] text-[color:var(--lens-ink)]/55">
-                  {formatDuration(audioFile.durationMs)} ·{" "}
-                  {audioFile.fileSizeBytes
-                    ? `${Math.round(audioFile.fileSizeBytes / 1024 / 1024)} MB`
-                    : "Size unavailable"}
-                </p>
-                {audioFile.isPrimary && (
-                  <p className="text-[11px] text-[color:var(--lens-blue)]">
-                    Primary audio
-                  </p>
-                )}
-              </section>
-              <FontAwesomeIcon
-                icon={faTrash}
-                onClick={(event) => {
-                  event.preventDefault();
-                  void onDeleteAudio(audioFile.id);
-                }}
-                className="text-[12px] cursor-pointer text-red-700 transition-colors hover:text-red-700 disabled:cursor-not-allowed disabled:opacity-50"
-              />
-            </header>
-            <a
-              href={audioFile.storagePath}
-              target="_blank"
-              rel="noreferrer"
-              className="mt-2 inline-flex text-[12px] text-[color:var(--lens-blue)] hover:underline"
+      <fieldset className="mt-4 border-none p-0">
+        <Input
+          type="file"
+          label={track?.audioFiles?.length ? "Replace audio" : "Upload audio"}
+          accept="audio/*"
+          onChange={(event) => void onAudioUpload(event)}
+          readOnly={isUploadingAudio}
+        />
+        <TrackUploadProgress
+          progress={uploadProgress}
+          phase={uploadPhase}
+          isUploading={isUploadingAudio}
+          isComplete={isUploadComplete}
+          fileName={uploadFileName}
+        />
+        {isDeletingAudio && (
+          <p className="mt-2 text-[12px] text-[color:var(--lens-ink)]/55">
+            Updating audio...
+          </p>
+        )}
+      </fieldset>
+
+      <ul className="mt-4 flex list-none flex-col gap-2 p-0">
+        {track?.audioFiles?.length ? (
+          track.audioFiles.map((audioFile) => (
+            <li
+              key={audioFile.id}
+              className="rounded-md border border-[color:var(--lens-sand)]/70 p-3"
             >
-              Open file
-            </a>
+              <header className="flex items-start justify-between gap-3">
+                <section className="space-y-1">
+                  <p className="text-[12px] font-normal text-[color:var(--lens-ink)]">
+                    {audioFile.fileType}
+                  </p>
+                  <p className="text-[11px] text-[color:var(--lens-ink)]/55">
+                    {formatDuration(audioFile.durationMs)} ·{" "}
+                    {audioFile.fileSizeBytes
+                      ? `${Math.round(audioFile.fileSizeBytes / 1024 / 1024)} MB`
+                      : "Size unavailable"}
+                  </p>
+                  {audioFile.isPrimary && (
+                    <p className="text-[11px] text-[color:var(--lens-blue)]">
+                      Primary audio
+                    </p>
+                  )}
+                </section>
+                <button
+                  type="button"
+                  onClick={() => void onDeleteAudio(audioFile.id)}
+                  disabled={isDeletingAudio}
+                  className="text-[12px] text-red-600 transition-colors hover:text-red-700 disabled:cursor-not-allowed disabled:opacity-50"
+                >
+                  Remove
+                </button>
+              </header>
+              <a
+                href={audioFile.storagePath}
+                target="_blank"
+                rel="noreferrer"
+                className="mt-2 inline-flex text-[12px] text-[color:var(--lens-blue)] hover:underline"
+              >
+                Open file
+              </a>
+            </li>
+          ))
+        ) : (
+          <li className="rounded-md border border-dashed border-[color:var(--lens-sand)]/70 p-3 text-[12px] text-[color:var(--lens-ink)]/55">
+            No audio uploaded yet.
           </li>
-        ))
-      ) : (
-        <li className="rounded-md border border-dashed border-[color:var(--lens-sand)]/70 p-3 text-[12px] text-[color:var(--lens-ink)]/55">
-          No audio uploaded yet.
-        </li>
-      )}
-    </ul>
-  </section>
-);
+        )}
+      </ul>
+    </section>
+  );
+};
 
 export default TrackAudioPanel;

--- a/client/src/state/api/apiMutationSlice.ts
+++ b/client/src/state/api/apiMutationSlice.ts
@@ -292,6 +292,22 @@ export const apiMutationSlice = createApi({
           method: "DELETE",
         }),
       }),
+
+      createLyrics: builder.mutation({
+        query: (body: Record<string, unknown>) => ({
+          url: "/lyrics",
+          method: "POST",
+          body,
+        }),
+      }),
+
+      updateLyrics: builder.mutation({
+        query: ({ id, body }: { id: string; body: Record<string, unknown> }) => ({
+          url: `/lyrics/${id}`,
+          method: "PATCH",
+          body,
+        }),
+      }),
     };
   },
 });
@@ -329,5 +345,7 @@ export const {
   useDeleteTrackContributorMutation,
   useCreateReleaseContributorMutation,
   useDeleteReleaseContributorMutation,
+  useCreateLyricsMutation,
+  useUpdateLyricsMutation,
 } = apiMutationSlice;
 export default apiMutationSlice;

--- a/client/src/state/api/apiQuerySlice.ts
+++ b/client/src/state/api/apiQuerySlice.ts
@@ -222,6 +222,26 @@ export const apiQuerySlice = createApi({
           };
         },
       }),
+
+      // FETCH LYRICS
+      fetchLyrics: builder.query({
+        query: ({ trackId, size = 100, page = 0 }: { trackId?: string; size?: number; page?: number }) => {
+          return {
+            url: "/lyrics",
+            method: "GET",
+            params: {
+              trackId,
+              size,
+              page,
+            },
+          };
+        },
+      }),
+
+      // GET LYRICS
+      getLyrics: builder.query({
+        query: ({ id }: { id: string }) => `/lyrics/${id}`,
+      }),
     };
   },
 });
@@ -242,5 +262,7 @@ export const {
   useLazyGetTrackQuery,
   useLazyFetchTrackContributorsQuery,
   useLazyFetchReleaseContributorsQuery,
+  useLazyFetchLyricsQuery,
+  useLazyGetLyricsQuery,
 } = apiQuerySlice;
 export default apiQuerySlice;

--- a/client/src/types/models/track.types.ts
+++ b/client/src/types/models/track.types.ts
@@ -49,8 +49,15 @@ export interface TrackContributor extends AbstractEntity {
   };
 }
 
-export interface TrackLyrics {
-  id: string;
+export interface TimedLyricLine {
+  time?: number;
+  text: string;
+}
+
+export interface TrackLyrics extends AbstractEntity {
+  trackId: string;
+  language: string;
+  content: TimedLyricLine[];
 }
 
 export interface Track extends AbstractEntity {


### PR DESCRIPTION
### Motivation
- Introduce structured, time-aware lyrics records so lyrics lines can be synced to audio with numeric timestamps.
- Provide create/update endpoints and ordered fetching to manage multiple lyrics records per track and support editing.
- Add a client-side editor to capture timestamps against the track's primary audio and a flow to create and persist lyrics records.

### Description
- Backend: change `Lyrics.content` time type from `string` to `number`, add `PATCH /lyrics/:id` handler and `updateLyrics` service, and order `fetchLyrics` by `createdAt` descending; include `lyrics` relation in track query.
- API surface: expose RTK Query endpoints and mutations `createLyrics`, `updateLyrics`, `fetchLyrics`, and `getLyrics` and export corresponding hooks.
- Types: add `TimedLyricLine` and extend `TrackLyrics` and `Track` types so tracks include `lyrics` arrays and typed lyric lines.
- UI: implement `CreateLyrics` form wired to `useCreateLyricsMutation`, implement full-featured `SyncLyrics` editor that loads track primary audio, lists/selects lyrics records, captures timestamps (Space or Sync now), and creates/updates records via mutations; add a "Sync lyrics" button in `TrackAudioPanel` and wire navigation from `ManageReleaseTrack` to open the sync editor.

### Testing
- Ran TypeScript typecheck and built both client and server to validate type and import changes, and the builds completed successfully.
- Ran the frontend lint and existing automated test suite, and no tests regressed or failed after the changes.
- Exercised RTK Query hooks in development to confirm create/fetch/update flows interact with the backend as expected.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c19c9cd6b8832dbb9f34851bb66c97)