### PR TITLE
Derive Display Artist from contributors and highlight Primary Artist in preview

### DIFF
--- a/client/src/pages/releases/wizard-steps/ReleaseWizardPreview.tsx
+++ b/client/src/pages/releases/wizard-steps/ReleaseWizardPreview.tsx
@@ -1,9 +1,10 @@
-import { useCallback, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { toast } from "sonner";
 import Button from "@/components/inputs/Button";
 import { useCreateReleaseNavigationFlow } from "@/hooks/releases/navigation.hooks";
 import { useValidateRelease } from "@/hooks/releases/release.hooks";
+import { useFetchReleaseContributors } from "@/hooks/releases/release-contributor.hooks";
 import { useAppSelector } from "@/state/hooks";
 import { ReleaseWizardStepProps } from "../ReleaseWizardPage";
 import PreviewValidationBanner from "./preview/PreviewValidationBanner";
@@ -23,6 +24,8 @@ const ReleaseWizardPreview = ({
   const { createReleaseNavigationFlow, isLoading: isNavigating } =
     useCreateReleaseNavigationFlow();
   const { validateRelease, isLoading: isValidating } = useValidateRelease();
+  const { fetchReleaseContributors, data: releaseContributorsData, isFetching: areContributorsFetching } =
+    useFetchReleaseContributors();
   const [validationResult, setValidationResult] =
     useState<ValidationResult | null>(null);
 
@@ -44,6 +47,12 @@ const ReleaseWizardPreview = ({
     }
   }, [release?.id, validateRelease, navigate]);
 
+  useEffect(() => {
+    if (release?.id) {
+      fetchReleaseContributors({ releaseId: release.id });
+    }
+  }, [fetchReleaseContributors, release?.id]);
+
   if (!release) {
     return (
       <section className="flex items-center justify-center p-8">
@@ -53,6 +62,8 @@ const ReleaseWizardPreview = ({
       </section>
     );
   }
+
+  const releaseContributors = releaseContributorsData?.data ?? [];
 
   return (
     <section className="flex w-full flex-col gap-5">
@@ -71,8 +82,12 @@ const ReleaseWizardPreview = ({
       <PreviewValidationBanner validationResult={validationResult} />
 
       <section className="flex flex-col gap-4">
-        <PreviewOverviewSection release={release} />
-        <PreviewContributorsSection releaseId={release.id} />
+        <PreviewOverviewSection release={release} contributors={releaseContributors} />
+        <PreviewContributorsSection
+          releaseId={release.id}
+          contributors={releaseContributors}
+          isLoading={areContributorsFetching}
+        />
         <PreviewTracksSection
           tracks={release.tracks ?? []}
           releaseId={release.id}

--- a/client/src/pages/releases/wizard-steps/preview/PreviewContributorsSection.tsx
+++ b/client/src/pages/releases/wizard-steps/preview/PreviewContributorsSection.tsx
@@ -4,7 +4,7 @@ import { ColumnDef } from "@tanstack/react-table";
 import Table from "@/components/table/Table";
 import DashboardSection from "@/pages/dashboard/components/DashboardSection";
 import { useFetchReleaseContributors } from "@/hooks/releases/release-contributor.hooks";
-import { ReleaseContributor } from "@/types/models/releaseContributor.types";
+import { ContributorRole, ReleaseContributor } from "@/types/models/releaseContributor.types";
 import { capitalizeString, formatDate } from "@/utils/strings.helper";
 import CustomPopover from "@/components/inputs/CustomPopover";
 import { faCircleInfo, faEllipsisH } from "@fortawesome/free-solid-svg-icons";
@@ -14,6 +14,8 @@ import { ellipsisHClassName } from "@/constants/input.constants";
 
 interface PreviewContributorsSectionProps {
   releaseId: string;
+  contributors?: ReleaseContributor[];
+  isLoading?: boolean;
 }
 
 const columns: ColumnDef<ReleaseContributor, string>[] = [
@@ -22,8 +24,11 @@ const columns: ColumnDef<ReleaseContributor, string>[] = [
     header: "Name",
     cell: ({ row }) => {
       const contributor = row.original.contributor;
+      const isPrimaryArtist = row.original.role === ContributorRole.PRIMARY_ARTIST;
       return (
-        <span className="text-[12px]">
+        <span
+          className={`text-[12px] ${isPrimaryArtist ? "font-semibold text-[color:var(--lens-ink)]" : "text-[color:var(--lens-ink)]/85"}`}
+        >
           {contributor?.displayName || contributor?.name || contributor?.email || "—"}
         </span>
       );
@@ -32,11 +37,20 @@ const columns: ColumnDef<ReleaseContributor, string>[] = [
   {
     accessorKey: "role",
     header: "Role",
-    cell: ({ row }) => (
-      <span className="rounded-full border border-[color:var(--lens-sand)] px-2 py-0.5 text-[11px]">
-        {capitalizeString(row.original.role)}
-      </span>
-    ),
+    cell: ({ row }) => {
+      const isPrimaryArtist = row.original.role === ContributorRole.PRIMARY_ARTIST;
+      return (
+        <span
+          className={`rounded-full px-2 py-0.5 text-[11px] ${
+            isPrimaryArtist
+              ? "border border-[color:var(--lens-gold)]/50 bg-[color:var(--lens-gold)]/15 font-semibold text-[color:var(--lens-ink)]"
+              : "border border-[color:var(--lens-sand)] text-[color:var(--lens-ink)]/90"
+          }`}
+        >
+          {isPrimaryArtist ? "Primary Artist" : capitalizeString(row.original.role)}
+        </span>
+      );
+    },
   },
   {
     accessorKey: `createdBy`,
@@ -77,17 +91,20 @@ const columns: ColumnDef<ReleaseContributor, string>[] = [
 
 const PreviewContributorsSection = ({
   releaseId,
+  contributors: contributorsFromProps,
+  isLoading: isLoadingFromProps = false,
 }: PreviewContributorsSectionProps) => {
   const { fetchReleaseContributors, data, isFetching } =
     useFetchReleaseContributors();
 
   useEffect(() => {
-    if (releaseId) {
+    if (!contributorsFromProps && releaseId) {
       fetchReleaseContributors({ releaseId });
     }
-  }, [fetchReleaseContributors, releaseId]);
+  }, [contributorsFromProps, fetchReleaseContributors, releaseId]);
 
-  const contributors: ReleaseContributor[] = data?.data ?? [];
+  const contributors: ReleaseContributor[] = contributorsFromProps ?? data?.data ?? [];
+  const contributorsAreLoading = contributorsFromProps ? isLoadingFromProps : isFetching;
 
   return (
     <motion.article
@@ -99,7 +116,7 @@ const PreviewContributorsSection = ({
         {contributors.length > 0 ? (
           <Table
             columns={columns}
-            isLoading={isFetching}
+            isLoading={contributorsAreLoading}
             data={contributors}
             showPagination={false}
             containerClassName="border-0"

--- a/client/src/pages/releases/wizard-steps/preview/PreviewOverviewSection.tsx
+++ b/client/src/pages/releases/wizard-steps/preview/PreviewOverviewSection.tsx
@@ -1,14 +1,37 @@
 import { motion } from "framer-motion";
 import Input from "@/components/inputs/Input";
 import DashboardSection from "@/pages/dashboard/components/DashboardSection";
+import { ContributorRole, ReleaseContributor } from "@/types/models/releaseContributor.types";
 import { Release } from "@/types/models/release.types";
 import { capitalizeString, formatDate } from "@/utils/strings.helper";
 
 interface PreviewOverviewSectionProps {
   release: Release;
+  contributors?: ReleaseContributor[];
 }
 
-const PreviewOverviewSection = ({ release }: PreviewOverviewSectionProps) => {
+const getContributorName = (contributor?: ReleaseContributor["contributor"]) =>
+  contributor?.displayName || contributor?.name || contributor?.email || "";
+
+const PreviewOverviewSection = ({
+  release,
+  contributors = [],
+}: PreviewOverviewSectionProps) => {
+  const primaryArtists = contributors
+    .filter((contributor) => contributor.role === ContributorRole.PRIMARY_ARTIST)
+    .map((contributor) => getContributorName(contributor.contributor))
+    .filter(Boolean);
+
+  const featuredArtists = contributors
+    .filter((contributor) => contributor.role === ContributorRole.FEATURED_ARTIST)
+    .map((contributor) => getContributorName(contributor.contributor))
+    .filter(Boolean);
+
+  const displayArtist =
+    primaryArtists.length > 0
+      ? `${primaryArtists.join(", ")}${featuredArtists.length > 0 ? ` feat. ${featuredArtists.join(", ")}` : ""}`
+      : "—";
+
   return (
     <motion.article
       initial={{ opacity: 0, y: 12 }}
@@ -38,6 +61,7 @@ const PreviewOverviewSection = ({ release }: PreviewOverviewSectionProps) => {
 
           <section className="grid w-full grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3">
             <Input label="Title" value={release.title || ""} readOnly />
+            <Input label="Display Artist" value={displayArtist} readOnly />
             <Input label="Title Version" value={release.titleVersion || "—"} readOnly />
             <Input label="Type" value={capitalizeString(release.type) || "—"} readOnly />
             <Input label="Language" value={release.primaryLanguage?.toUpperCase() || "—"} readOnly />


### PR DESCRIPTION
### Motivation
- Show a clear, human-friendly "Display Artist" in the release overview derived from release contributors rather than relying only on release artist models.
- Append featured artists using `feat.` alongside primary artists for correct display of artist credits.
- Make primary artist credits visually distinct in the contributors table to improve UX when reviewing credits.
- Avoid duplicate fetches by using a single contributor dataset passed from the parent preview view while keeping the contributors section compatible with its existing hook.

### Description
- Fetch release contributors in `ReleaseWizardPreview` using `useFetchReleaseContributors` and pass `contributors` and loading state to child components (`PreviewOverviewSection` and `PreviewContributorsSection`).
- Add `contributors?: ReleaseContributor[]` prop to `PreviewOverviewSection` and derive `displayArtist` from contributors with role `PRIMARY_ARTIST` (fallback `displayName -> name -> email`) and append `FEATURED_ARTIST` contributors as `feat.`; add a new `Display Artist` `Input` row in the overview grid (`PreviewOverviewSection.tsx`).
- Update `PreviewContributorsSection` to accept `contributors?` and `isLoading?` props, defer fetching when contributors are provided, and compute `contributorsAreLoading` accordingly, keeping backward-compatible hook-based fetching when no prop is given (`PreviewContributorsSection.tsx`).
- Emphasize primary artists visually by strengthening the contributor name style and using a highlighted role badge for `PRIMARY_ARTIST` entries, and normalize role checks to use the `ContributorRole` enum.

### Testing
- Ran `npx eslint` on the modified files (`src/pages/releases/wizard-steps/ReleaseWizardPreview.tsx`, `PreviewOverviewSection.tsx`, `PreviewContributorsSection.tsx`) which passed.
- Ran `npm run lint` for the entire client which failed due to pre-existing unrelated lint errors in other files and not related to these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c2e17d8ea0832d912dc84d86a0888b)