### PR TITLE
Add cover art dimensions, uploader metadata, and validation

### DIFF
--- a/api/src/entities/release.entity.ts
+++ b/api/src/entities/release.entity.ts
@@ -41,6 +41,12 @@ export class Release extends AbstractEntity {
   @Column({ name: 'cover_art_url', type: 'varchar', length: 1024, nullable: true })
   coverArtUrl?: string;
 
+  @Column({ name: 'cover_art_width', type: 'integer', nullable: true })
+  coverArtWidth?: number;
+
+  @Column({ name: 'cover_art_height', type: 'integer', nullable: true })
+  coverArtHeight?: number;
+
   // PRODUCTION YEAR
   @Column({ name: 'production_year', type: 'integer', nullable: true })
   productionYear: number;

--- a/api/src/migrations/1711286400000-add-cover-art-dimensions-to-releases.ts
+++ b/api/src/migrations/1711286400000-add-cover-art-dimensions-to-releases.ts
@@ -1,0 +1,23 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddCoverArtDimensionsToReleases1711286400000 implements MigrationInterface {
+  name = 'AddCoverArtDimensionsToReleases1711286400000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      'ALTER TABLE "releases" ADD "cover_art_width" integer',
+    );
+    await queryRunner.query(
+      'ALTER TABLE "releases" ADD "cover_art_height" integer',
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      'ALTER TABLE "releases" DROP COLUMN "cover_art_height"',
+    );
+    await queryRunner.query(
+      'ALTER TABLE "releases" DROP COLUMN "cover_art_width"',
+    );
+  }
+}

--- a/api/src/modules/releases/releases.service.ts
+++ b/api/src/modules/releases/releases.service.ts
@@ -1,4 +1,4 @@
-import { ForbiddenException, Injectable, NotFoundException } from '@nestjs/common';
+import { BadRequestException, ForbiddenException, Injectable, NotFoundException } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { Release } from '../../entities/release.entity';
@@ -17,6 +17,8 @@ import { UpdateReleaseTerritoriesDto } from './dto/update-release-territories.dt
 
 @Injectable()
 export class ReleaseService {
+  private static readonly MIN_COVER_ART_DIMENSION = 3000;
+
   constructor(
     @InjectRepository(Release)
     private readonly releaseRepository: Repository<Release>,
@@ -91,6 +93,12 @@ export class ReleaseService {
     });
 
     release.coverArtUrl = uploadedCoverArt.secureUrl;
+    release.coverArtWidth = uploadedCoverArt.width;
+    release.coverArtHeight = uploadedCoverArt.height;
+
+    if (uploadedCoverArt.colorMode && uploadedCoverArt.colorMode.toLowerCase() !== 'rgb') {
+      throw new BadRequestException('Cover art must use RGB color mode');
+    }
 
     return this.releaseRepository.save(release);
   }
@@ -145,6 +153,21 @@ export class ReleaseService {
 
     if (!release.coverArtUrl) {
       errors.push('Cover art is required');
+    }
+
+    if (!release.coverArtWidth || !release.coverArtHeight) {
+      errors.push('Cover art dimensions are required');
+    } else {
+      if (
+        release.coverArtWidth < ReleaseService.MIN_COVER_ART_DIMENSION
+        || release.coverArtHeight < ReleaseService.MIN_COVER_ART_DIMENSION
+      ) {
+        errors.push('Cover art must be at least 3000x3000 pixels');
+      }
+
+      if (release.coverArtWidth !== release.coverArtHeight) {
+        errors.push('Cover art must have a square aspect ratio');
+      }
     }
 
     if (!release.originalReleaseDate) {

--- a/api/src/modules/uploads/cloudinary-image-uploader.service.ts
+++ b/api/src/modules/uploads/cloudinary-image-uploader.service.ts
@@ -17,8 +17,11 @@ export interface UploadedImageResult {
   publicId: string;
   originalName: string;
   bytes: number;
+  width: number;
+  height: number;
   format?: string;
   resourceType: string;
+  colorMode?: string;
 }
 
 @Injectable()
@@ -48,8 +51,11 @@ export class CloudinaryImageUploaderService {
         publicId: result.public_id,
         originalName: file.originalname,
         bytes: result.bytes,
+        width: result.width,
+        height: result.height,
         format: result.format,
         resourceType: result.resource_type,
+        colorMode: this.extractColorMode(result.metadata),
       };
     } catch (error) {
       throw new InternalServerErrorException('Failed to upload image');
@@ -95,5 +101,16 @@ export class CloudinaryImageUploaderService {
 
       stream.end(buffer);
     });
+  }
+
+  private extractColorMode(metadata: unknown): string | undefined {
+    if (!metadata || typeof metadata !== 'object') {
+      return undefined;
+    }
+
+    const metadataRecord = metadata as Record<string, unknown>;
+    const colorMode = metadataRecord.color_mode ?? metadataRecord.color_space;
+
+    return typeof colorMode === 'string' ? colorMode : undefined;
   }
 }


### PR DESCRIPTION
### Motivation
- Persist cover-art width/height so uploads can be validated against platform requirements. 
- Surface image dimensions and optional color-mode from Cloudinary so the service can enforce minimum size, square aspect ratio, and (optionally) RGB color mode. 

### Description
- Added nullable `coverArtWidth` and `coverArtHeight` properties to the `Release` entity and mapped them to `cover_art_width` / `cover_art_height` DB columns in `api/src/entities/release.entity.ts`.
- Added a TypeORM migration `api/src/migrations/1711286400000-add-cover-art-dimensions-to-releases.ts` that adds and rolls back the two new columns.
- Extended the Cloudinary uploader result type in `api/src/modules/uploads/cloudinary-image-uploader.service.ts` to include `width`, `height`, and an optional `colorMode` extracted from upload metadata, and returned those fields from `uploadImage`.
- Updated `ReleaseService.uploadCoverArt` in `api/src/modules/releases/releases.service.ts` to persist `coverArtUrl`, `coverArtWidth`, and `coverArtHeight`, and to reject non-RGB `colorMode` values when metadata is present.
- Updated `ReleaseService.validateRelease` to require stored cover-art dimensions, enforce a minimum of `3000x3000` pixels, and require a square aspect ratio; the minimum is implemented as `MIN_COVER_ART_DIMENSION = 3000`.

### Testing
- Built the API TypeScript project with `npm run build` (run from `api/`) and the TypeScript compilation completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c2e17a6730832d843a50d2218bbe8f)