### PR TITLE
Add UPC and ISRC validation and normalization for releases and tracks

### DIFF
--- a/api/src/helpers/releases.helper.ts
+++ b/api/src/helpers/releases.helper.ts
@@ -3,3 +3,27 @@ import { generateRandomNumber } from "./strings.helper";
 export const generateCatalogNumber = (length: number = 6, productionYear: number = new Date().getFullYear()) => {
     return `LNS${productionYear}${generateRandomNumber(length)}`;
 };
+
+export const isValidUpc = (upc: string): boolean => {
+    if (!/^\d{12,13}$/.test(upc)) {
+        return false;
+    }
+
+    const digits = upc.split("").map(Number);
+    const checkDigit = digits.pop();
+
+    if (checkDigit === undefined) {
+        return false;
+    }
+
+    const sum = digits
+        .slice()
+        .reverse()
+        .reduce((total, digit, index) => {
+            return total + digit * (index % 2 === 0 ? 3 : 1);
+        }, 0);
+
+    const computedCheckDigit = (10 - (sum % 10)) % 10;
+
+    return computedCheckDigit === checkDigit;
+};

--- a/api/src/helpers/tracks.helper.ts
+++ b/api/src/helpers/tracks.helper.ts
@@ -1,0 +1,7 @@
+export const normalizeIsrc = (isrc: string): string => {
+    return isrc.replace(/[-\s]/g, "").toUpperCase();
+};
+
+export const isValidIsrc = (isrc: string): boolean => {
+    return /^[A-Z]{2}[A-Z0-9]{3}[0-9]{7}$/.test(isrc);
+};

--- a/api/src/modules/releases/dto/update-release-overview.dto.ts
+++ b/api/src/modules/releases/dto/update-release-overview.dto.ts
@@ -45,6 +45,11 @@ export class UpdateReleaseOverviewDto {
   @MaxLength(255)
   version?: string;
 
+  @IsOptional()
+  @IsString()
+  @MaxLength(14)
+  upc?: string;
+
   @Type(() => Number)
   @IsInt()
   productionYear!: number;

--- a/api/src/modules/releases/releases.service.ts
+++ b/api/src/modules/releases/releases.service.ts
@@ -6,7 +6,7 @@ import { ReleaseContributor } from '../../entities/release-contributor.entity';
 import { TrackStatus } from '../../entities/track.entity';
 import { CreateReleaseDto } from './dto/create-release.dto';
 import { UUID } from '../../types/common.types';
-import { generateCatalogNumber } from '../../helpers/releases.helper';
+import { generateCatalogNumber, isValidUpc } from '../../helpers/releases.helper';
 import { CloudinaryImageUploaderService } from '../uploads/cloudinary-image-uploader.service';
 import { AuthUser } from '../../common/decorators/current-user.decorator';
 import { ROLES } from '../../constants/auth.constant';
@@ -47,6 +47,7 @@ export class ReleaseService {
     release.type = dto.type;
     release.titleVersion = dto.titleVersion?.trim() || undefined;
     release.version = dto.version?.trim() || undefined;
+    release.upc = dto.upc?.trim() || undefined;
     release.productionYear = dto.productionYear;
     release.originalReleaseDate = dto.originalReleaseDate;
     release.digitalReleaseDate = dto.digitalReleaseDate;
@@ -133,6 +134,12 @@ export class ReleaseService {
 
     if (!release.primaryLanguage) {
       errors.push('Primary language is required');
+    }
+
+    if (!release.upc) {
+      errors.push('UPC is required');
+    } else if (!isValidUpc(release.upc)) {
+      errors.push('UPC format is invalid');
     }
 
     if (!release.cLine?.year || !release.cLine?.owner) {

--- a/api/src/modules/tracks/tracks.service.ts
+++ b/api/src/modules/tracks/tracks.service.ts
@@ -9,6 +9,7 @@ import { RegisterAudioDto } from './dto/register-audio.dto';
 import { UUID } from '../../types/common.types';
 import { CloudinaryAudioUploaderService, UploadSignatureResult } from '../uploads/cloudinary-audio-uploader.service';
 import { TrackStatus } from '../../entities/track.entity';
+import { isValidIsrc, normalizeIsrc } from '../../helpers/tracks.helper';
 
 @Injectable()
 export class TrackService {
@@ -23,6 +24,10 @@ export class TrackService {
   private normalizeTrackStringFields<T extends Partial<Track>>(track: T): T {
     if (typeof track.primaryLanguage === 'string') {
       track.primaryLanguage = track.primaryLanguage.trim() as T['primaryLanguage'];
+    }
+
+    if (typeof track.isrc === 'string') {
+      track.isrc = normalizeIsrc(track.isrc) as T['isrc'];
     }
 
     return track;
@@ -95,6 +100,16 @@ export class TrackService {
 
     if (!track.primaryLanguage) {
       errors.push('Primary language is required');
+    }
+
+    const normalizedIsrc = typeof track.isrc === 'string' ? normalizeIsrc(track.isrc) : undefined;
+
+    if (!normalizedIsrc) {
+      errors.push('ISRC is required');
+    } else if (!isValidIsrc(normalizedIsrc)) {
+      errors.push('ISRC format is invalid');
+    } else if (track.isrc !== normalizedIsrc) {
+      track.isrc = normalizedIsrc;
     }
 
     if (!track.cLineYear) {


### PR DESCRIPTION
### Motivation
- Ensure releases and tracks have correct UPC/ISRC values before allowing validation and state transitions to reduce downstream metadata errors.
- Normalize ISRC inputs (strip separators and uppercase) so stored values are consistent for lookups and uniqueness.

### Description
- Added `isValidUpc(upc)` to `api/src/helpers/releases.helper.ts` implementing 12/13-digit numeric check-digit validation (GTIN-style) and exported it for reuse.
- Added `normalizeIsrc` and `isValidIsrc` to new `api/src/helpers/tracks.helper.ts` where `normalizeIsrc` strips hyphens/spaces and uppercases and `isValidIsrc` uses the regex `^[A-Z]{2}[A-Z0-9]{3}[0-9]{7}$`.
- Extended `UpdateReleaseOverviewDto` to accept optional `upc` and updated `ReleaseService.updateOverview` to persist `upc` from the DTO.
- In `ReleaseService.validateRelease` added required UPC checks and an invalid-format error using `isValidUpc`.
- In `TrackService` added ISRC normalization in `normalizeTrackStringFields` and in `validateTrack` made ISRC required, validated its format via `isValidIsrc`, and normalize/save the ISRC before allowing the track to be marked `VALIDATED`.

### Testing
- Ran TypeScript build with `npm run build` in `api/` and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c2e179a034832d94a807e0b16fd6c6)