### PR TITLE
Add DSP store catalog and release store assignment workflow

### DIFF
--- a/api/src/app.module.ts
+++ b/api/src/app.module.ts
@@ -15,6 +15,7 @@ import { TracksModule } from './modules/tracks/tracks.module';
 import { TrackContributorsModule } from './modules/track-contributors/track-contributors.module';
 import { ReleaseContributorsModule } from './modules/release-contributors/release-contributors.module';
 import { GenresModule } from './modules/genres/genres.module';
+import { StoresModule } from './modules/stores/stores.module';
 
 @Module({
   imports: [
@@ -54,6 +55,7 @@ import { GenresModule } from './modules/genres/genres.module';
     TrackContributorsModule,
     ReleaseContributorsModule,
     GenresModule,
+    StoresModule,
   ],
 })
 export class AppModule {}

--- a/api/src/constants/store.constants.ts
+++ b/api/src/constants/store.constants.ts
@@ -1,0 +1,24 @@
+export enum ReleaseDeliveryStatus {
+  PENDING = 'PENDING',
+  IN_PROGRESS = 'IN_PROGRESS',
+  DELIVERED = 'DELIVERED',
+  FAILED = 'FAILED',
+}
+
+export const DEFAULT_DSP_STORES = [
+  { name: 'Spotify', slug: 'spotify' },
+  { name: 'Apple Music', slug: 'apple-music' },
+  { name: 'Amazon Music', slug: 'amazon-music' },
+  { name: 'Deezer', slug: 'deezer' },
+  { name: 'TIDAL', slug: 'tidal' },
+  { name: 'YouTube Music', slug: 'youtube-music' },
+  { name: 'TikTok', slug: 'tiktok' },
+  { name: 'Instagram/Facebook', slug: 'instagram-facebook' },
+  { name: 'Pandora', slug: 'pandora' },
+  { name: 'SoundCloud', slug: 'soundcloud' },
+  { name: 'Boomplay', slug: 'boomplay' },
+  { name: 'Audiomack', slug: 'audiomack' },
+  { name: 'Anghami', slug: 'anghami' },
+  { name: 'Napster', slug: 'napster' },
+  { name: 'iHeartRadio', slug: 'iheartradio' },
+];

--- a/api/src/entities/release-store.entity.ts
+++ b/api/src/entities/release-store.entity.ts
@@ -1,0 +1,40 @@
+import {
+  Column,
+  Entity,
+  JoinColumn,
+  ManyToOne,
+  Unique,
+} from 'typeorm';
+import { AbstractEntity } from './abstract.entity';
+import { UUID } from '../types/common.types';
+import { Release } from './release.entity';
+import { Store } from './store.entity';
+import { ReleaseDeliveryStatus } from '../constants/store.constants';
+
+@Entity('release_stores')
+@Unique(['releaseId', 'storeId'])
+export class ReleaseStore extends AbstractEntity {
+  @Column({ name: 'release_id', type: 'uuid', nullable: false })
+  releaseId!: UUID;
+
+  @Column({ name: 'store_id', type: 'uuid', nullable: false })
+  storeId!: UUID;
+
+  @Column({
+    name: 'delivery_status',
+    type: 'enum',
+    enum: ReleaseDeliveryStatus,
+    nullable: false,
+    default: ReleaseDeliveryStatus.PENDING,
+  })
+  deliveryStatus!: ReleaseDeliveryStatus;
+
+
+  @ManyToOne(() => Release, { onDelete: 'CASCADE', onUpdate: 'CASCADE' })
+  @JoinColumn({ name: 'release_id' })
+  release!: Release;
+
+  @ManyToOne(() => Store, { onDelete: 'CASCADE', onUpdate: 'CASCADE' })
+  @JoinColumn({ name: 'store_id' })
+  store!: Store;
+}

--- a/api/src/entities/release.entity.ts
+++ b/api/src/entities/release.entity.ts
@@ -1,68 +1,85 @@
-import {
-  Column,
-  Entity,
-  OneToMany,
-  Unique,
-} from 'typeorm';
-import { AbstractEntity } from './abstract.entity';
-import { Track } from './track.entity';
-import { ReleaseNavigationFlow } from './release-navigation-flow.entity';
-import { ReleaseGenre } from './release-genre.entity';
+import { Column, Entity, OneToMany, Unique } from "typeorm";
+import { AbstractEntity } from "./abstract.entity";
+import { Track } from "./track.entity";
+import { ReleaseNavigationFlow } from "./release-navigation-flow.entity";
+import { ReleaseGenre } from "./release-genre.entity";
+import { ReleaseStore } from "./release-store.entity";
 import {
   ReleaseParentalAdvisory,
   ReleaseRightsLine,
   ReleaseStatus,
   ReleaseType,
-} from '../constants/release.constants';
+} from "../constants/release.constants";
 
-@Entity('releases')
+@Entity("releases")
 @Unique([
-  'title',
-  'digitalReleaseDate',
-  'originalReleaseDate',
-  'preorderDate',
-  'productionYear',
-  'version',
+  "title",
+  "digitalReleaseDate",
+  "originalReleaseDate",
+  "preorderDate",
+  "productionYear",
+  "version",
 ])
 export class Release extends AbstractEntity {
   // TITLE
-  @Column({ name: 'title', type: 'varchar', length: 500, nullable: false })
+  @Column({ name: "title", type: "varchar", length: 500, nullable: false })
   title!: string;
 
   // UPC
-  @Column({ name: 'upc', type: 'varchar', length: 14, nullable: true, unique: true })
+  @Column({
+    name: "upc",
+    type: "varchar",
+    length: 14,
+    nullable: true,
+    unique: true,
+  })
   upc?: string;
 
   // VERSION
-  @Column({ name: 'version', type: 'varchar', length: 255, nullable: true })
+  @Column({ name: "version", type: "varchar", length: 255, nullable: true })
   version?: string;
 
   // COVER ART
-  @Column({ name: 'cover_art_url', type: 'varchar', length: 1024, nullable: true })
+  @Column({
+    name: "cover_art_url",
+    type: "varchar",
+    length: 1024,
+    nullable: true,
+  })
   coverArtUrl?: string;
 
-  @Column({ name: 'cover_art_width', type: 'integer', nullable: true })
+  @Column({ name: "cover_art_width", type: "integer", nullable: true })
   coverArtWidth?: number;
 
-  @Column({ name: 'cover_art_height', type: 'integer', nullable: true })
+  @Column({ name: "cover_art_height", type: "integer", nullable: true })
   coverArtHeight?: number;
 
   // PRODUCTION YEAR
-  @Column({ name: 'production_year', type: 'integer', nullable: true })
+  @Column({ name: "production_year", type: "integer", nullable: true })
   productionYear: number;
 
   // CATALOG NUMBER
-  @Column({ name: 'catalog_number', type: 'varchar', length: 50, nullable: true })
+  @Column({
+    name: "catalog_number",
+    type: "varchar",
+    length: 50,
+    nullable: true,
+  })
   catalogNumber?: string;
 
   // TITLE VERSION
-  @Column({ name: 'title_version', type: 'varchar', length: 255, nullable: true })
+  @Column({
+    name: "title_version",
+    type: "varchar",
+    length: 255,
+    nullable: true,
+  })
   titleVersion?: string;
 
   // RELEASE TYPE
   @Column({
-    name: 'type',
-    type: 'enum',
+    name: "type",
+    type: "enum",
     enum: ReleaseType,
     nullable: true,
     default: ReleaseType.ALBUM,
@@ -70,33 +87,38 @@ export class Release extends AbstractEntity {
   type?: ReleaseType;
 
   // PRIMARY LANGUAGE
-  @Column({ name: 'primary_language', type: 'varchar', length: 5, nullable: true })
+  @Column({
+    name: "primary_language",
+    type: "varchar",
+    length: 5,
+    nullable: true,
+  })
   primaryLanguage?: string;
 
   // C LINE
-  @Column({ name: 'c_line', type: 'jsonb', nullable: true })
+  @Column({ name: "c_line", type: "jsonb", nullable: true })
   cLine?: ReleaseRightsLine | null;
 
   // P LINE
-  @Column({ name: 'p_line', type: 'jsonb', nullable: true })
+  @Column({ name: "p_line", type: "jsonb", nullable: true })
   pLine?: ReleaseRightsLine | null;
 
   // ORIGINAL RELEASE DATE
-  @Column({ name: 'original_release_date', type: 'date', nullable: true })
+  @Column({ name: "original_release_date", type: "date", nullable: true })
   originalReleaseDate?: string;
 
   // DIGITAL RELEASE DATE
-  @Column({ name: 'digital_release_date', type: 'date', nullable: true })
+  @Column({ name: "digital_release_date", type: "date", nullable: true })
   digitalReleaseDate?: string;
 
   // PREORDER DATE
-  @Column({ name: 'preorder_date', type: 'date', nullable: true })
+  @Column({ name: "preorder_date", type: "date", nullable: true })
   preorderDate?: string;
 
   // PARENTAL ADVISORY
   @Column({
-    name: 'parental_advisory',
-    type: 'enum',
+    name: "parental_advisory",
+    type: "enum",
     enum: ReleaseParentalAdvisory,
     nullable: false,
     default: ReleaseParentalAdvisory.NOT_EXPLICIT,
@@ -105,8 +127,8 @@ export class Release extends AbstractEntity {
 
   // STATUS
   @Column({
-    name: 'status',
-    type: 'enum',
+    name: "status",
+    type: "enum",
     enum: ReleaseStatus,
     nullable: false,
     default: ReleaseStatus.DRAFT,
@@ -114,17 +136,26 @@ export class Release extends AbstractEntity {
   status!: ReleaseStatus;
 
   // METADATA LANGUAGE
-  @Column({ name: 'metadata_language', type: 'varchar', length: 5, nullable: true })
+  @Column({
+    name: "metadata_language",
+    type: "varchar",
+    length: 5,
+    nullable: true,
+  })
   metadataLanguage?: string;
 
   // TERRITORIES
-  @Column({ name: 'territories', type: 'jsonb', nullable: true, default: () => "'[]'" })
+  @Column({
+    name: "territories",
+    type: "jsonb",
+    nullable: true,
+    default: () => "'[]'",
+  })
   territories?: string[];
 
   // TRACKS
   @OneToMany(() => Track, (track) => track.release)
   tracks!: Track[];
-
 
   // RELEASE NAVIGATION FLOWS
   @OneToMany(
@@ -136,4 +167,7 @@ export class Release extends AbstractEntity {
   // RELEASE GENRES
   @OneToMany(() => ReleaseGenre, (releaseGenre) => releaseGenre.release)
   genres!: ReleaseGenre[];
+  // RELEASE STORES
+  @OneToMany(() => ReleaseStore, (releaseStore) => releaseStore.release)
+  releaseStores!: ReleaseStore[];
 }

--- a/api/src/entities/store.entity.ts
+++ b/api/src/entities/store.entity.ts
@@ -1,0 +1,23 @@
+import { Column, Entity, OneToMany, Unique } from 'typeorm';
+import { AbstractEntity } from './abstract.entity';
+import { ReleaseStore } from './release-store.entity';
+
+@Entity('stores')
+@Unique(['name'])
+@Unique(['slug'])
+export class Store extends AbstractEntity {
+  @Column({ name: 'name', type: 'varchar', length: 255, nullable: false })
+  name!: string;
+
+  @Column({ name: 'slug', type: 'varchar', length: 255, nullable: false })
+  slug!: string;
+
+  @Column({ name: 'is_active', type: 'boolean', nullable: false, default: true })
+  isActive!: boolean;
+
+  @Column({ name: 'sort_order', type: 'integer', nullable: false, default: 0 })
+  sortOrder!: number;
+
+  @OneToMany(() => ReleaseStore, (releaseStore) => releaseStore.store)
+  releaseStores!: ReleaseStore[];
+}

--- a/api/src/modules/stores/dto/assign-release-stores.dto.ts
+++ b/api/src/modules/stores/dto/assign-release-stores.dto.ts
@@ -1,0 +1,9 @@
+import { ArrayUnique, IsArray, IsUUID } from 'class-validator';
+import { UUID } from '../../../types/common.types';
+
+export class AssignReleaseStoresDto {
+  @IsArray()
+  @ArrayUnique()
+  @IsUUID('4', { each: true })
+  storeIds!: UUID[];
+}

--- a/api/src/modules/stores/stores.controller.ts
+++ b/api/src/modules/stores/stores.controller.ts
@@ -1,0 +1,68 @@
+import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  HttpCode,
+  HttpStatus,
+  Param,
+  Post,
+  UseGuards,
+} from '@nestjs/common';
+import { JwtAuthGuard } from '../../common/guards/jwt-auth.guard';
+import { StoresService } from './stores.service';
+import {
+  AuthUser,
+  CurrentUser,
+} from '../../common/decorators/current-user.decorator';
+import { AssignReleaseStoresDto } from './dto/assign-release-stores.dto';
+
+@Controller()
+@UseGuards(JwtAuthGuard)
+export class StoresController {
+  constructor(private readonly storesService: StoresService) {}
+
+  @Get('stores')
+  async fetchStores() {
+    const stores = await this.storesService.fetchStores();
+    return { message: 'Stores fetched successfully', data: stores };
+  }
+
+  @Post('releases/:id/stores')
+  @HttpCode(HttpStatus.CREATED)
+  async assignReleaseStores(
+    @Param('id') releaseId: string,
+    @Body() dto: AssignReleaseStoresDto,
+    @CurrentUser() user: AuthUser,
+  ) {
+    const releaseStores = await this.storesService.assignReleaseStores(
+      releaseId,
+      dto,
+      user.id,
+    );
+
+    return {
+      message: 'Release stores assigned successfully',
+      data: releaseStores,
+    };
+  }
+
+  @Get('releases/:id/stores')
+  async findReleaseStores(@Param('id') releaseId: string) {
+    const releaseStores = await this.storesService.findReleaseStores(releaseId);
+    return {
+      message: 'Release stores fetched successfully',
+      data: releaseStores,
+    };
+  }
+
+  @Delete('releases/:id/stores/:releaseStoreId')
+  @HttpCode(HttpStatus.OK)
+  async deleteReleaseStore(
+    @Param('id') releaseId: string,
+    @Param('releaseStoreId') releaseStoreId: string,
+  ) {
+    await this.storesService.deleteReleaseStore(releaseId, releaseStoreId);
+    return { message: 'Release store removed successfully' };
+  }
+}

--- a/api/src/modules/stores/stores.module.ts
+++ b/api/src/modules/stores/stores.module.ts
@@ -1,0 +1,14 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { StoresController } from './stores.controller';
+import { StoresService } from './stores.service';
+import { Store } from '../../entities/store.entity';
+import { Release } from '../../entities/release.entity';
+import { ReleaseStore } from '../../entities/release-store.entity';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([Store, Release, ReleaseStore])],
+  controllers: [StoresController],
+  providers: [StoresService],
+})
+export class StoresModule {}

--- a/api/src/modules/stores/stores.service.ts
+++ b/api/src/modules/stores/stores.service.ts
@@ -1,0 +1,117 @@
+import {
+  Injectable,
+  NotFoundException,
+} from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { In, Repository } from 'typeorm';
+import { Store } from '../../entities/store.entity';
+import { Release } from '../../entities/release.entity';
+import { ReleaseStore } from '../../entities/release-store.entity';
+import { UUID } from '../../types/common.types';
+import { AssignReleaseStoresDto } from './dto/assign-release-stores.dto';
+import { ReleaseStatus } from '../../constants/release.constants';
+
+@Injectable()
+export class StoresService {
+  constructor(
+    @InjectRepository(Store)
+    private readonly storeRepository: Repository<Store>,
+    @InjectRepository(Release)
+    private readonly releaseRepository: Repository<Release>,
+    @InjectRepository(ReleaseStore)
+    private readonly releaseStoreRepository: Repository<ReleaseStore>,
+  ) {}
+
+  async fetchStores(): Promise<Store[]> {
+    return this.storeRepository.find({
+      where: { isActive: true },
+      order: { sortOrder: 'ASC', name: 'ASC' },
+    });
+  }
+
+  async assignReleaseStores(
+    releaseId: UUID,
+    dto: AssignReleaseStoresDto,
+    createdById: UUID,
+  ): Promise<ReleaseStore[]> {
+    const release = await this.releaseRepository.findOne({ where: { id: releaseId } });
+
+    if (!release) {
+      throw new NotFoundException('Release not found');
+    }
+
+    const storeIds = dto.storeIds || [];
+    const stores = storeIds.length
+      ? await this.storeRepository.find({ where: { id: In(storeIds) } })
+      : [];
+
+    if (stores.length !== storeIds.length) {
+      throw new NotFoundException('One or more stores were not found');
+    }
+
+    const existingReleaseStores = await this.releaseStoreRepository.find({
+      where: { releaseId },
+    });
+
+    const existingByStoreId = new Map(existingReleaseStores.map((item) => [item.storeId, item]));
+
+    const toCreate = storeIds
+      .filter((storeId) => !existingByStoreId.has(storeId))
+      .map((storeId) =>
+        this.releaseStoreRepository.create({
+          releaseId,
+          storeId,
+          createdById,
+        }),
+      );
+
+    const selectedStoreIds = new Set(storeIds);
+    const toDeleteIds = existingReleaseStores
+      .filter((item) => !selectedStoreIds.has(item.storeId))
+      .map((item) => item.id);
+
+    if (toCreate.length > 0) {
+      await this.releaseStoreRepository.save(toCreate);
+    }
+
+    if (toDeleteIds.length > 0) {
+      await this.releaseStoreRepository.delete(toDeleteIds);
+    }
+
+    await this.releaseRepository.update(releaseId, { status: ReleaseStatus.DRAFT });
+
+    return this.findReleaseStores(releaseId);
+  }
+
+  async findReleaseStores(releaseId: UUID): Promise<ReleaseStore[]> {
+    const release = await this.releaseRepository.findOne({ where: { id: releaseId } });
+
+    if (!release) {
+      throw new NotFoundException('Release not found');
+    }
+
+    return this.releaseStoreRepository.find({
+      where: { releaseId },
+      relations: ['store', 'createdBy'],
+      order: {
+        store: {
+          sortOrder: 'ASC',
+          name: 'ASC',
+        },
+      },
+    });
+  }
+
+  async deleteReleaseStore(releaseId: UUID, releaseStoreId: UUID): Promise<void> {
+    const releaseStore = await this.releaseStoreRepository.findOne({
+      where: { id: releaseStoreId, releaseId },
+    });
+
+    if (!releaseStore) {
+      throw new NotFoundException('Release store assignment not found');
+    }
+
+    await this.releaseStoreRepository.delete(releaseStoreId);
+    await this.releaseRepository.update(releaseId, { status: ReleaseStatus.DRAFT });
+  }
+}

--- a/api/src/seeds/index.ts
+++ b/api/src/seeds/index.ts
@@ -6,10 +6,18 @@ import { seedPermissions } from './permission.seeds';
 import { seedUsers } from './user.seeds';
 import { seedRoles } from './role.seeds';
 import { seedStaticReleaseNavigation } from './static-release-navigation.seeds';
+import { seedStores } from './store.seeds';
 import { seedGenres } from './genre.seeds';
 
 /** Users before roles so SUPER_ADMIN seed can attach permissions and assign the admin user. */
-const seeds = [seedPermissions, seedUsers, seedRoles, seedStaticReleaseNavigation, seedGenres];
+const seeds = [
+  seedPermissions,
+  seedUsers,
+  seedRoles,
+  seedStaticReleaseNavigation,
+  seedStores,
+  seedGenres,
+];
 
 const runSeeds = async () => {
   logger.info('Connecting to database...');

--- a/api/src/seeds/store.seeds.ts
+++ b/api/src/seeds/store.seeds.ts
@@ -1,0 +1,35 @@
+import { DataSource } from 'typeorm';
+import { Store } from '../entities/store.entity';
+import { DEFAULT_DSP_STORES } from '../constants/store.constants';
+import logger from '../utils/logger';
+
+export const seedStores = async (dataSource: DataSource) => {
+  const storeRepo = dataSource.getRepository(Store);
+  const seedLog = logger.child({ seed: 'stores' });
+
+  for (const [index, store] of DEFAULT_DSP_STORES.entries()) {
+    const existing = await storeRepo.findOne({ where: { slug: store.slug } });
+
+    if (existing) {
+      await storeRepo.update(existing.id, {
+        name: store.name,
+        sortOrder: index,
+        isActive: true,
+      });
+      continue;
+    }
+
+    await storeRepo.save(
+      storeRepo.create({
+        ...store,
+        sortOrder: index,
+        isActive: true,
+      }),
+    );
+  }
+
+  seedLog.info(
+    { count: DEFAULT_DSP_STORES.length },
+    'Default DSP stores seed complete',
+  );
+};

--- a/client/src/hooks/releases/release-store.hooks.ts
+++ b/client/src/hooks/releases/release-store.hooks.ts
@@ -1,0 +1,26 @@
+import {
+  useAssignReleaseStoresMutation,
+  useDeleteReleaseStoreMutation,
+} from '@/state/api/apiMutationSlice';
+import { useLazyFetchReleaseStoresQuery } from '@/state/api/apiQuerySlice';
+
+export const useFetchReleaseStores = () => {
+  const [fetchReleaseStores, { data, isFetching, isSuccess }] =
+    useLazyFetchReleaseStoresQuery();
+
+  return { fetchReleaseStores, data, isFetching, isSuccess };
+};
+
+export const useAssignReleaseStores = () => {
+  const [assignReleaseStores, { data, isLoading, isSuccess, isError, error, reset }] =
+    useAssignReleaseStoresMutation();
+
+  return { assignReleaseStores, data, isLoading, isSuccess, isError, error, reset };
+};
+
+export const useDeleteReleaseStore = () => {
+  const [deleteReleaseStore, { data, isLoading, isSuccess, isError, error, reset }] =
+    useDeleteReleaseStoreMutation();
+
+  return { deleteReleaseStore, data, isLoading, isSuccess, isError, error, reset };
+};

--- a/client/src/hooks/stores/store.hooks.ts
+++ b/client/src/hooks/stores/store.hooks.ts
@@ -1,0 +1,8 @@
+import { useLazyFetchStoresQuery } from '@/state/api/apiQuerySlice';
+
+export const useFetchStores = () => {
+  const [fetchStores, { data, isFetching, isSuccess }] =
+    useLazyFetchStoresQuery();
+
+  return { fetchStores, data, isFetching, isSuccess };
+};

--- a/client/src/pages/releases/wizard-steps/ReleaseWizardPreview.tsx
+++ b/client/src/pages/releases/wizard-steps/ReleaseWizardPreview.tsx
@@ -12,6 +12,7 @@ import PreviewOverviewSection from "./preview/PreviewOverviewSection";
 import PreviewContributorsSection from "./preview/PreviewContributorsSection";
 import PreviewTracksSection from "./preview/PreviewTracksSection";
 import PreviewTerritoriesSection from "./preview/PreviewTerritoriesSection";
+import PreviewStoresSection from "./preview/PreviewStoresSection";
 
 type ValidationResult = { valid: boolean; errors: string[] };
 
@@ -94,6 +95,7 @@ const ReleaseWizardPreview = ({
           isLoading={releaseIsFetching ?? false}
         />
         <PreviewTerritoriesSection territories={release.territories ?? []} />
+        <PreviewStoresSection releaseId={release.id} />
       </section>
 
       <footer className="flex w-full items-center justify-between gap-3">

--- a/client/src/pages/releases/wizard-steps/ReleaseWizardStores.tsx
+++ b/client/src/pages/releases/wizard-steps/ReleaseWizardStores.tsx
@@ -1,34 +1,158 @@
-import Button from "@/components/inputs/Button";
-import { ReleaseWizardStepProps } from "../ReleaseWizardPage";
-import { useCreateReleaseNavigationFlow } from "@/hooks/releases/navigation.hooks";
-import { useAppSelector } from "@/state/hooks";
+import { useEffect, useMemo, useState } from 'react';
+import { toast } from 'sonner';
+import Button from '@/components/inputs/Button';
+import Input from '@/components/inputs/Input';
+import { useCreateReleaseNavigationFlow } from '@/hooks/releases/navigation.hooks';
+import { useFetchStores } from '@/hooks/stores/store.hooks';
+import {
+  useAssignReleaseStores,
+  useFetchReleaseStores,
+} from '@/hooks/releases/release-store.hooks';
+import { useAppSelector } from '@/state/hooks';
+import { Store } from '@/types/models/store.types';
+import { ReleaseWizardStepProps } from '../ReleaseWizardPage';
 
 const ReleaseWizardStores = ({
   nextStepName,
   previousStepName,
 }: ReleaseWizardStepProps) => {
-  // STATE VARIABLES
   const { release } = useAppSelector((state) => state.release);
 
-  // CREATE RELEASE NAVIGATION FLOW
-  const { createReleaseNavigationFlow, isLoading } =
+  const [selectedStoreIds, setSelectedStoreIds] = useState<string[]>([]);
+
+  const { createReleaseNavigationFlow, isLoading: isNavigating } =
     useCreateReleaseNavigationFlow();
+  const { fetchStores, data: storesResponse, isFetching: storesIsFetching } =
+    useFetchStores();
+  const {
+    fetchReleaseStores,
+    data: releaseStoresResponse,
+    isFetching: releaseStoresIsFetching,
+  } = useFetchReleaseStores();
+  const { assignReleaseStores, isLoading: isAssigning } = useAssignReleaseStores();
+
+  useEffect(() => {
+    fetchStores({});
+  }, [fetchStores]);
+
+  useEffect(() => {
+    if (release?.id) {
+      fetchReleaseStores({ releaseId: release.id });
+    }
+  }, [fetchReleaseStores, release?.id]);
+
+  useEffect(() => {
+    const assignedStoreIds =
+      releaseStoresResponse?.data?.map((releaseStore: { storeId: string }) => releaseStore.storeId) ?? [];
+    setSelectedStoreIds(assignedStoreIds);
+  }, [releaseStoresResponse]);
+
+  const stores: Store[] = storesResponse?.data ?? [];
+
+  const allSelected = useMemo(
+    () => stores.length > 0 && selectedStoreIds.length === stores.length,
+    [selectedStoreIds.length, stores.length],
+  );
+
+  const toggleStoreSelection = (storeId: string, checked: boolean) => {
+    setSelectedStoreIds((current) => {
+      if (checked) {
+        return current.includes(storeId) ? current : [...current, storeId];
+      }
+      return current.filter((id) => id !== storeId);
+    });
+  };
+
+  const saveAndContinue = async () => {
+    if (!release?.id || !nextStepName) {
+      return;
+    }
+
+    try {
+      await assignReleaseStores({
+        id: release.id,
+        storeIds: selectedStoreIds,
+      }).unwrap();
+
+      createReleaseNavigationFlow({
+        releaseId: release.id,
+        staticReleaseNavigationStepName: nextStepName,
+      });
+    } catch (error) {
+      const errorMessage =
+        (error as { data?: { message?: string } })?.data?.message ||
+        'Failed to assign stores to this release.';
+      toast.error(errorMessage);
+    }
+  };
 
   return (
     <section className="w-full flex flex-col gap-4">
-      <h2 className="text-xl font-semibold text-gray-900">Stores</h2>
-      <p className="mt-3 max-w-2xl text-sm leading-6 text-gray-500">
-        Your release will be delivered to all 150+ partner stores.
-        Select-by-store targeting is coming soon.
-      </p>
+      <header>
+        <h2 className="text-xl font-semibold text-gray-900">Stores</h2>
+        <p className="mt-1 max-w-2xl text-sm leading-6 text-gray-500">
+          Select the stores where this release should be delivered.
+        </p>
+      </header>
+
+      <section className="flex flex-wrap items-center gap-2">
+        <Button
+          onClick={(event) => {
+            event.preventDefault();
+            setSelectedStoreIds(stores.map((store) => store.id));
+          }}
+        >
+          Select all
+        </Button>
+        <Button
+          onClick={(event) => {
+            event.preventDefault();
+            setSelectedStoreIds([]);
+          }}
+        >
+          Deselect all
+        </Button>
+        <span className="text-[12px] text-[color:var(--lens-ink)]/60">
+          {selectedStoreIds.length} of {stores.length} selected
+        </span>
+      </section>
+
+      <section className="grid grid-cols-1 gap-3 rounded-xl border border-[color:var(--lens-sand)]/70 p-4 sm:grid-cols-2 lg:grid-cols-3">
+        {storesIsFetching || releaseStoresIsFetching ? (
+          <p className="text-[12px] text-[color:var(--lens-ink)]/55">Loading stores...</p>
+        ) : stores.length === 0 ? (
+          <p className="text-[12px] text-[color:var(--lens-ink)]/55">No stores available.</p>
+        ) : (
+          stores.map((store) => (
+            <article
+              key={store.id}
+              className="rounded-lg border border-[color:var(--lens-sand)]/60 bg-white px-3 py-2"
+            >
+              <Input
+                type="checkbox"
+                label={store.name}
+                checked={selectedStoreIds.includes(store.id)}
+                onChange={(checked) => toggleStoreSelection(store.id, Boolean(checked))}
+              />
+            </article>
+          ))
+        )}
+      </section>
+
+      {!allSelected && stores.length > 0 && (
+        <p className="text-[11px] text-[color:var(--lens-ink)]/50">
+          Tip: Use Select all for global distribution, then deselect stores you do not want.
+        </p>
+      )}
+
       <footer className="w-full flex items-center justify-between gap-3">
         <Button
-          isLoading={isLoading}
+          isLoading={isNavigating}
           onClick={(event) => {
             event.preventDefault();
             if (previousStepName && release?.id) {
               createReleaseNavigationFlow({
-                releaseId: release?.id,
+                releaseId: release.id,
                 staticReleaseNavigationStepName: previousStepName,
               });
             }
@@ -37,16 +161,11 @@ const ReleaseWizardStores = ({
           Back
         </Button>
         <Button
-          isLoading={isLoading}
+          isLoading={isAssigning || isNavigating}
           primary
           onClick={(event) => {
             event.preventDefault();
-            if (nextStepName && release?.id) {
-              createReleaseNavigationFlow({
-                releaseId: release?.id,
-                staticReleaseNavigationStepName: nextStepName,
-              });
-            }
+            void saveAndContinue();
           }}
         >
           Save and continue

--- a/client/src/pages/releases/wizard-steps/preview/PreviewStoresSection.tsx
+++ b/client/src/pages/releases/wizard-steps/preview/PreviewStoresSection.tsx
@@ -1,0 +1,52 @@
+import { useEffect } from 'react';
+import { motion } from 'framer-motion';
+import DashboardSection from '@/pages/dashboard/components/DashboardSection';
+import { useFetchReleaseStores } from '@/hooks/releases/release-store.hooks';
+import { ReleaseStore } from '@/types/models/releaseStore.types';
+
+interface PreviewStoresSectionProps {
+  releaseId: string;
+}
+
+const PreviewStoresSection = ({ releaseId }: PreviewStoresSectionProps) => {
+  const { fetchReleaseStores, data, isFetching } = useFetchReleaseStores();
+
+  useEffect(() => {
+    if (releaseId) {
+      fetchReleaseStores({ releaseId });
+    }
+  }, [fetchReleaseStores, releaseId]);
+
+  const releaseStores: ReleaseStore[] = data?.data ?? [];
+
+  return (
+    <motion.article
+      initial={{ opacity: 0, y: 12 }}
+      animate={{ opacity: 1, y: 0 }}
+      transition={{ delay: 0.3, duration: 0.35, ease: 'easeOut' }}
+    >
+      <DashboardSection title="Stores" label="Distribution">
+        {isFetching ? (
+          <p className="text-[12px] text-[color:var(--lens-ink)]/55">Loading stores...</p>
+        ) : releaseStores.length > 0 ? (
+          <ul className="flex flex-wrap gap-1.5">
+            {releaseStores.map((releaseStore) => (
+              <li
+                key={releaseStore.id}
+                className="rounded-full border border-[color:var(--lens-sand)] bg-[color:var(--lens-sand)]/20 px-2.5 py-0.5 text-[11px] text-[color:var(--lens-ink)]/70"
+              >
+                {releaseStore.store?.name || 'Unknown store'}
+              </li>
+            ))}
+          </ul>
+        ) : (
+          <p className="text-[12px] text-[color:var(--lens-ink)]/55">
+            No stores selected yet.
+          </p>
+        )}
+      </DashboardSection>
+    </motion.article>
+  );
+};
+
+export default PreviewStoresSection;

--- a/client/src/state/api/apiMutationSlice.ts
+++ b/client/src/state/api/apiMutationSlice.ts
@@ -320,6 +320,21 @@ export const apiMutationSlice = createApi({
         }),
       }),
 
+
+      assignReleaseStores: builder.mutation({
+        query: ({ id, storeIds }: { id: string; storeIds: string[] }) => ({
+          url: `/releases/${id}/stores`,
+          method: 'POST',
+          body: { storeIds },
+        }),
+      }),
+
+      deleteReleaseStore: builder.mutation({
+        query: ({ id, releaseStoreId }: { id: string; releaseStoreId: string }) => ({
+          url: `/releases/${id}/stores/${releaseStoreId}`,
+          method: 'DELETE',
+        }),
+      }),
       createLyrics: builder.mutation({
         query: (body: Record<string, unknown>) => ({
           url: "/lyrics",
@@ -382,6 +397,8 @@ export const {
   useDeleteTrackContributorMutation,
   useCreateReleaseContributorMutation,
   useDeleteReleaseContributorMutation,
+  useAssignReleaseStoresMutation,
+  useDeleteReleaseStoreMutation,
   useCreateLyricsMutation,
   useUpdateLyricsMutation,
   useDeleteLyricsMutation,

--- a/client/src/state/api/apiQuerySlice.ts
+++ b/client/src/state/api/apiQuerySlice.ts
@@ -215,6 +215,22 @@ export const apiQuerySlice = createApi({
         },
       }),
 
+
+      // FETCH STORES
+      fetchStores: builder.query({
+        query: () => ({
+          url: '/stores',
+          method: 'GET',
+        }),
+      }),
+
+      // FETCH RELEASE STORES
+      fetchReleaseStores: builder.query({
+        query: ({ releaseId }: { releaseId: string }) => ({
+          url: `/releases/${releaseId}/stores`,
+          method: 'GET',
+        }),
+      }),
       // FETCH RELEASE CONTRIBUTORS
       fetchReleaseContributors: builder.query({
         query: ({ releaseId }: { releaseId: string }) => {
@@ -268,6 +284,8 @@ export const {
   useLazyGetTrackQuery,
   useLazyFetchTrackContributorsQuery,
   useLazyFetchReleaseContributorsQuery,
+  useLazyFetchStoresQuery,
+  useLazyFetchReleaseStoresQuery,
   useLazyFetchLyricsQuery,
   useLazyGetLyricsQuery,
 } = apiQuerySlice;

--- a/client/src/types/models/release.types.ts
+++ b/client/src/types/models/release.types.ts
@@ -2,6 +2,7 @@ import { AbstractEntity } from './index.types';
 import { User } from './user.types';
 import { Track } from './track.types';
 import { ReleaseGenre } from './releaseGenre.types';
+import { ReleaseStore } from './releaseStore.types';
 
 export enum ReleaseType {
   ALBUM = 'ALBUM',
@@ -54,4 +55,5 @@ export interface Release extends AbstractEntity {
   createdBy?: User | null;
   tracks: Track[];
   genres: ReleaseGenre[];
+  releaseStores?: ReleaseStore[];
 }

--- a/client/src/types/models/releaseStore.types.ts
+++ b/client/src/types/models/releaseStore.types.ts
@@ -1,0 +1,17 @@
+import { AbstractEntity } from './index.types';
+import { Store } from './store.types';
+
+export enum ReleaseDeliveryStatus {
+  PENDING = 'PENDING',
+  IN_PROGRESS = 'IN_PROGRESS',
+  DELIVERED = 'DELIVERED',
+  FAILED = 'FAILED',
+}
+
+export interface ReleaseStore extends AbstractEntity {
+  releaseId: string;
+  storeId: string;
+  deliveryStatus: ReleaseDeliveryStatus;
+  createdById?: string;
+  store?: Store;
+}

--- a/client/src/types/models/store.types.ts
+++ b/client/src/types/models/store.types.ts
@@ -1,0 +1,8 @@
+import { AbstractEntity } from './index.types';
+
+export interface Store extends AbstractEntity {
+  name: string;
+  slug: string;
+  isActive: boolean;
+  sortOrder: number;
+}


### PR DESCRIPTION
### Motivation
- Add a first-class model for DSP stores so releases can be targeted per-store during distribution. 
- Persist store assignments per release and track delivery status for downstream delivery processing. 
- Provide API endpoints to manage store assignments and make a seeded default DSP catalog available at startup. 
- Expose store data to the frontend and replace the placeholder UI with a usable selection flow to improve the release wizard experience.

### Description
- Added `ReleaseDeliveryStatus` enum and `DEFAULT_DSP_STORES` catalog in `api/src/constants/store.constants.ts` and a `seedStores` seed in `api/src/seeds/store.seeds.ts`. 
- Introduced `Store` (`api/src/entities/store.entity.ts`) and `ReleaseStore` (`api/src/entities/release-store.entity.ts`) entities with a unique `(releaseId, storeId)` constraint and a `deliveryStatus` enum column. 
- Wired a `releaseStores` `OneToMany` relation into `Release` and registered a `StoresModule` with a service and controller that implement `GET /stores`, `POST /releases/:id/stores` (bulk assign/replace), `GET /releases/:id/stores`, and `DELETE /releases/:id/stores/:releaseStoreId`. 
- Added DTO validation (`AssignReleaseStoresDto`), release status reset to `DRAFT` on assignment changes, and included the stores seed in `api/src/seeds/index.ts`. 
- Frontend changes include new types `client/src/types/models/store.types.ts` and `client/src/types/models/releaseStore.types.ts`, RTK Query endpoints in `apiQuerySlice`/`apiMutationSlice`, hooks in `client/src/hooks/stores` and `client/src/hooks/releases`, and UI updates. 
- Replaced the placeholder `ReleaseWizardStores` with a checkbox grid (select all / deselect all) and persistence via `useAssignReleaseStores`, and added `PreviewStoresSection` to the release preview step. 

### Testing
- Ran backend build with `cd api && npm run build` and it completed successfully. 
- Ran frontend build with `cd client && npm run build` and it completed successfully. 
- Ran frontend lint with `cd client && npm run lint` which failed due to pre-existing unrelated lint errors (reported as existing issues in other files), so lint is not green but failures are not introduced by these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c2e178e4c8832dad6c42af16542b24)